### PR TITLE
adding naive/trivial support for cdata

### DIFF
--- a/lib/Sabre/XML/Element/Cdata.php
+++ b/lib/Sabre/XML/Element/Cdata.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Sabre\XML\Element;
+
+use Sabre\XML;
+
+class Cdata implements XML\Element
+{
+    private $value;
+
+    public function __construct($value = NULL)
+    {
+        $this->value = $value;
+    }
+
+    public function serializeXml(XML\Writer $writer)
+    {
+        $writer->writeCData($this->value);
+    }
+
+    public static function deserializeXml(XML\Reader $reader)
+    {
+        return $reader->parseInnerTree;
+    }
+}


### PR DESCRIPTION
This makes it simple to invoke XML\Writer::write() on an array with cdata
things like so:

``` php
$writer = new Sabre\XML\Writer();
$writer->openMemory();
$writer->setIndent(true);
$writer->startDocument('1.0', 'UTF-8');
$writer->write(
  array(
    'my-sweet-node' => array(
      'a-cdata-node' => new Cdata('some cool text in a cdata')
    )
  )
);
```

``` XML
<?xml version="1.0" encoding="UTF-8"?>
<my-sweet-node>
 <a-cdata-node><![CDATA[some cool text in a cdata]]></a-cdata-node>
</my-sweet-node>
```
