### PR TITLE
Allow mixing short syntax with a more verbose syntax.

### DIFF
--- a/tests/Sabre/XML/WriterTest.php
+++ b/tests/Sabre/XML/WriterTest.php
@@ -39,6 +39,68 @@ HI
 
     }
 
+    function testSimpleAttributes() {
+
+        $this->compare([
+            '{http://sabredav.org/ns}root' => [
+                'value' => 'text',
+                'attributes' => [
+                    'attr1' => 'attribute value',
+                ],
+            ],
+        ], <<<HI
+<?xml version="1.0"?>
+<s:root xmlns:s="http://sabredav.org/ns" attr1="attribute value">text</s:root>
+
+HI
+        );
+
+    }
+
+    function testMixedSyntax() {
+        $this->compare([
+            '{http://sabredav.org/ns}root' => [
+                'single' => 'value',
+                'multiple' => [
+                    [
+                        'name' => 'foo',
+                        'value' => 'bar',
+                    ],
+                    [
+                        'name' => 'foo',
+                        'value' => 'foobar',
+                    ],
+                ],
+                'attributes' => [
+                    'value' => null,
+                    'attributes' => [
+                        'foo' => 'bar',
+                    ],
+                ],
+                [
+                    'name' => 'verbose',
+                    'value' => 'syntax',
+                    'attributes' => [
+                        'foo' => 'bar',
+                    ],
+                ],
+            ],
+        ], <<<HI
+<?xml version="1.0"?>
+<s:root xmlns:s="http://sabredav.org/ns">
+ <single>value</single>
+ <multiple>
+  <foo>bar</foo>
+  <foo>foobar</foo>
+ </multiple>
+ <attributes foo="bar"/>
+ <verbose foo="bar">syntax</verbose>
+</s:root>
+
+HI
+        );
+    }
+
     function testNull() {
 
         $this->compare([


### PR DESCRIPTION
Verbose syntax would be an array of with "name" and "value" attributes, such as:

``` php
[
    'name' => 'foo',
    'value' => 'bar',
]
```

Since there are no attributes this could be written using a short syntax, such as:

``` php
[
    'foo' => 'bar',
]
```

With this change we now are able to mix those syntax, eg:

``` php
[
    'short' => 'syntax',
    [
        'name' => 'verbose',
        'value' => 'syntax',
    ],
]
```

The "verbose" syntax is supposed to be used when having multiple elements with same name or when a element has attributes.
