### PR TITLE
Non-namespaced elements now return $this->localName (if it's not null).

### DIFF
--- a/lib/Sabre/XML/Reader.php
+++ b/lib/Sabre/XML/Reader.php
@@ -53,6 +53,9 @@ class Reader extends XMLReader {
     public function getClark() {
 
         if (!$this->namespaceURI) {
+            if (isset($this->localName)) {
+                return $this->localName;
+            }
             return null;
         }
         return '{' . $this->namespaceURI . '}' . $this->localName;


### PR DESCRIPTION
This is a change I made to sabre-xml based on [issue #6](https://github.com/fruux/sabre-xml/issues/6).  It's a small fix--and I was using it internally--but I thought I might as well submit a pull request just in case anyone else wants to use it.
