### PR TITLE
Parse Elements Not in a Namespace

### DIFF
--- a/lib/Sabre/XML/Reader.php
+++ b/lib/Sabre/XML/Reader.php
@@ -46,15 +46,18 @@ class Reader extends XMLReader {
      * Returns the current nodename in clark-notation.
      *
      * For example: "{http://www.w3.org/2005/Atom}feed".
+     * Or if no namespace is defined: "{}feed".
+     *
      * This method returns null if we're not currently on an element.
      *
      * @return string|null
      */
     public function getClark() {
 
-        if (!$this->namespaceURI) {
+        if (! $this->localName) {
             return null;
         }
+
         return '{' . $this->namespaceURI . '}' . $this->localName;
 
     }

--- a/tests/Sabre/XML/ReaderTest.php
+++ b/tests/Sabre/XML/ReaderTest.php
@@ -30,8 +30,20 @@ BLA;
 
         $reader->next();
 
-        $this->assertNull($reader->getClark());
+        $this->assertEquals('{}root', $reader->getClark());
 
+    }
+
+    function testGetClarkNotOnAnElement() {
+
+        $input = <<<BLA
+<?xml version="1.0"?>
+<root />
+BLA;
+        $reader = new Reader();
+        $reader->xml($input);
+
+        $this->assertNull($reader->getClark());
     }
 
     function testSimple() {


### PR DESCRIPTION
Same as #11 except that the clark name of elements with undefined namespace will will be prefixed with "{}".

For example "{}feed".
