### PR TITLE
Add the getElementName method

### DIFF
--- a/lib/Element.php
+++ b/lib/Element.php
@@ -56,4 +56,12 @@ interface Element {
      */
     static function deserializeXml(Reader $reader);
 
+    /**
+     * Get element name.
+     *
+     * @param Reader $reader
+     * @return string|null
+     */
+    static function getElementName(Reader $reader);
+
 }

--- a/lib/Element/Base.php
+++ b/lib/Element/Base.php
@@ -84,5 +84,17 @@ class Base implements XML\Element {
 
     }
 
+    /**
+     * Get element name.
+     *
+     * @param XML\Reader $reader
+     * @return string|null
+     */
+    static function getElementName(Xml\Reader $reader) {
+
+        return $reader->getClark();
+
+    }
+
 }
 

--- a/lib/Element/Cdata.php
+++ b/lib/Element/Cdata.php
@@ -86,4 +86,16 @@ class Cdata implements XML\Element
 
     }
 
+    /**
+     * Get element name.
+     *
+     * @param XML\Reader $reader
+     * @return null
+     */
+    static function getElementName(XML\Reader $reader) {
+
+        return null;
+
+    }
+
 }

--- a/lib/Element/Elements.php
+++ b/lib/Element/Elements.php
@@ -109,13 +109,25 @@ class Elements implements XML\Element {
         do {
 
             if ($reader->nodeType === XML\Reader::ELEMENT) {
-                $values[] = $reader->getClark();
+                $values[] = static::getElementName($reader);
             }
 
         } while($reader->depth >= $currentDepth && $reader->next());
 
         $reader->next();
         return $values;
+
+    }
+
+    /**
+     * Get element name.
+     *
+     * @param XML\Reader $reader
+     * @return string|null
+     */
+    static function getElementName(XML\Reader $reader) {
+
+        return $reader->getClark();
 
     }
 

--- a/lib/Element/KeyValue.php
+++ b/lib/Element/KeyValue.php
@@ -109,8 +109,8 @@ class KeyValue implements XML\Element {
 
             if ($reader->nodeType === XML\Reader::ELEMENT) {
 
-                $clark = $reader->getClark();
-                $values[$clark] = $reader->parseCurrentElement()['value'];
+                $name = static::getElementName($reader);
+                $values[$name] = $reader->parseCurrentElement()['value'];
 
             } else {
                 $reader->read();
@@ -121,6 +121,18 @@ class KeyValue implements XML\Element {
         $reader->read();
 
         return $values;
+
+    }
+
+    /**
+     * Get element name.
+     *
+     * @param XML\Reader $reader
+     * @return string|null
+     */
+    static function getElementName(XML\Reader $reader) {
+
+        return $reader->getClark();
 
     }
 

--- a/tests/Sabre/XML/Element/Eater.php
+++ b/tests/Sabre/XML/Element/Eater.php
@@ -75,4 +75,16 @@ class Eater implements XML\Element {
 
     }
 
+    /**
+     * Get element name.
+     *
+     * @param XML\Reader $reader
+     * @return string|null
+     */
+    static function getElementName(XML\Reader $reader) {
+
+        return $reader->getClark();
+
+    }
+
 }

--- a/tests/Sabre/XML/Element/Mock.php
+++ b/tests/Sabre/XML/Element/Mock.php
@@ -57,4 +57,16 @@ class Mock implements XML\Element {
 
     }
 
+    /**
+     * Get element name.
+     *
+     * @param XML\Reader $reader
+     * @return string|null
+     */
+    static function getElementName(XML\Reader $reader) {
+
+        return $reader->getClark();
+
+    }
+
 }


### PR DESCRIPTION
Because this method is used in all `Element` classes to compute the tag name, this is then easier to modify how the tag name is computed, for instance it is easier to remove the clark notation by extending an `Element` class.

Used to simplify maintenance of https://github.com/fruux/sabre-vobject/pull/160.
