### PR TITLE
Fix default namespace attributes

### DIFF
--- a/lib/Writer.php
+++ b/lib/Writer.php
@@ -248,7 +248,8 @@ class Writer extends XMLWriter {
         if (array_key_exists($namespace, $this->namespaceMap)) {
             // It's an attribute with a namespace we know
             return $this->writeAttribute(
-                $this->namespaceMap[$namespace] . ':' . $localName,
+            	$this->namespaceMap[$namespace] === '' ? $localName :
+                	($this->namespaceMap[$namespace] . ':' . $localName),
                 $value
             );
 


### PR DESCRIPTION
Currently using namespaceMap with empty key does correctly write elements, but does not correctly write attributes (it writes `:attribute=` instead of `attribute=`).

This should fix the problem.