### PR TITLE
Prevent infinite loops for empty props element

### DIFF
--- a/lib/Deserializer/functions.php
+++ b/lib/Deserializer/functions.php
@@ -74,7 +74,9 @@ function keyValue(Reader $reader, string $namespace = null) : array {
                 $values[$clark] = $reader->parseCurrentElement()['value'];
             }
         } else {
-            $reader->read();
+            if (!$reader->read()) {
+                break;
+            }
         }
     } while ($reader->nodeType !== Reader::END_ELEMENT);
 


### PR DESCRIPTION
If you do a propfind with:

```xml
<?xml version="1.0"?>
<a:propfind xmlns:a="DAV:">
  <a:prop></a:prop>
</a:propfind>
```

And have this parsed:

```php
use Sabre\DAV\Xml\Service;

$content = '<?xml version="1.0"?><a:propfind xmlns:a="DAV:"><a:prop></a:prop></a:propfind>';

$xml = new Service();
$xml->expect('{DAV:}propfind', $content);
```

Then this results in an infinite loop.
This patch breaks out of the loop once the reader fails to read.