### PR TITLE
Throw exception when empty inputs found

### DIFF
--- a/lib/Service.php
+++ b/lib/Service.php
@@ -108,6 +108,11 @@ class Service
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
             $input = stream_get_contents($input);
+
+            // If input is an empty string, then its safe to throw exception
+            if ('' === $input) {
+                throw new ParseException('The input element to parse is empty. Do not attempt to parse');
+            }
         }
         $r = $this->getReader();
         $r->contextUri = $contextUri;
@@ -147,6 +152,11 @@ class Service
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
             $input = stream_get_contents($input);
+
+            // If input is empty string, then its safe to throw exception
+            if ('' === $input) {
+                throw new ParseException('The input element to parse is empty. Do not attempt to parse');
+            }
         }
         $r = $this->getReader();
         $r->contextUri = $contextUri;

--- a/tests/Sabre/Xml/ServiceTest.php
+++ b/tests/Sabre/Xml/ServiceTest.php
@@ -36,6 +36,15 @@ class ServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($ns, $writer->namespaceMap);
     }
 
+    public function testEmptyInputParse()
+    {
+        $resource = fopen('php://input', 'r');
+        $util = new Service();
+        $this->expectException('\Sabre\Xml\ParseException');
+        $this->expectExceptionMessage('The input element to parse is empty. Do not attempt to parse');
+        $util->parse($resource, '/sabre.io/ns');
+    }
+
     /**
      * @depends testGetReader
      */
@@ -94,6 +103,16 @@ XML;
             $expected,
             $result
         );
+    }
+
+    public function testEmptyInputExpect()
+    {
+        //$resource = \fopen('')
+        $resource = fopen('php://input', 'r');
+        $util = new Service();
+        $this->expectException('\Sabre\Xml\ParseException');
+        $this->expectExceptionMessage('The input element to parse is empty. Do not attempt to parse');
+        $util->expect('foo', $resource, '/sabre.io/ns');
     }
 
     /**


### PR DESCRIPTION
When input retrieved from stream_get_contents
is empty string, then it would be safe to return
from the parse and expect methods.

Signed-off-by: Sujith H <sharidasan@owncloud.com>