### PR TITLE
Throw exception when empty inputs found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ ChangeLog
 * #144: Added a new `functionCaller` deserializer function for executing a callable when reading a XML
 element (@vsouz4)
 
+
+2.1.3 (2019-08-14)
+------------------
+
+* #166: Throw exception when empty inputs found
+
+
+2.1.2 (2019-01-09)
+------------------
+
+* #161: Prevent infinite loop on empty xml elements
+
+
 2.1.1 (2018-10-09)
 ------------------
 

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit" : "*"
+        "phpunit/phpunit" : "^6"
     },
     "config" : {
         "bin-dir" : "bin/"

--- a/lib/Service.php
+++ b/lib/Service.php
@@ -115,6 +115,11 @@ class Service
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
             $input = (string) stream_get_contents($input);
+
+            // If input is an empty string, then its safe to throw exception
+            if ('' === $input) {
+                throw new ParseException('The input element to parse is empty. Do not attempt to parse');
+            }
         }
         $r = $this->getReader();
         $r->contextUri = $contextUri;
@@ -154,6 +159,11 @@ class Service
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
             $input = (string) stream_get_contents($input);
+
+            // If input is empty string, then its safe to throw exception
+            if ('' === $input) {
+                throw new ParseException('The input element to parse is empty. Do not attempt to parse');
+            }
         }
         $r = $this->getReader();
         $r->contextUri = $contextUri;

--- a/tests/Sabre/Xml/ServiceTest.php
+++ b/tests/Sabre/Xml/ServiceTest.php
@@ -36,6 +36,15 @@ class ServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($ns, $writer->namespaceMap);
     }
 
+    public function testEmptyInputParse()
+    {
+        $resource = fopen('php://input', 'r');
+        $util = new Service();
+        $this->expectException('\Sabre\Xml\ParseException');
+        $this->expectExceptionMessage('The input element to parse is empty. Do not attempt to parse');
+        $util->parse($resource, '/sabre.io/ns');
+    }
+
     /**
      * @depends testGetReader
      */
@@ -94,6 +103,16 @@ XML;
             $expected,
             $result
         );
+    }
+
+    public function testEmptyInputExpect()
+    {
+        //$resource = \fopen('')
+        $resource = fopen('php://input', 'r');
+        $util = new Service();
+        $this->expectException('\Sabre\Xml\ParseException');
+        $this->expectExceptionMessage('The input element to parse is empty. Do not attempt to parse');
+        $util->expect('foo', $resource, '/sabre.io/ns');
     }
 
     /**


### PR DESCRIPTION
When input retrieved from stream_get_contents
is empty string, then it would be safe to throw
exceptions from the parse and expect methods.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

master version of #166 