### PR TITLE
xml cannot be empty while reading

### DIFF
--- a/lib/Service.php
+++ b/lib/Service.php
@@ -115,12 +115,13 @@ class Service
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
             $input = (string) stream_get_contents($input);
-
-            // If input is an empty string, then its safe to throw exception
-            if ('' === $input) {
-                throw new ParseException('The input element to parse is empty. Do not attempt to parse');
-            }
         }
+
+        // If input is empty, then its safe to throw exception
+        if (empty($input)) {
+            throw new ParseException('The input element to parse is empty. Do not attempt to parse');
+        }
+
         $r = $this->getReader();
         $r->contextUri = $contextUri;
         $r->XML($input, null, $this->options);
@@ -158,12 +159,13 @@ class Service
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
             $input = (string) stream_get_contents($input);
-
-            // If input is empty string, then its safe to throw exception
-            if ('' === $input) {
-                throw new ParseException('The input element to parse is empty. Do not attempt to parse');
-            }
         }
+
+        // If input is empty, then its safe to throw exception
+        if (empty($input)) {
+            throw new ParseException('The input element to parse is empty. Do not attempt to parse');
+        }
+
         $r = $this->getReader();
         $r->contextUri = $contextUri;
         $r->XML($input, null, $this->options);

--- a/tests/Sabre/Xml/ServiceTest.php
+++ b/tests/Sabre/Xml/ServiceTest.php
@@ -36,13 +36,18 @@ class ServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($ns, $writer->namespaceMap);
     }
 
-    public function testEmptyInputParse()
+    /**
+     * @dataProvider providesEmptyInput
+     *
+     * @param string|resource $input
+     */
+    public function testEmptyInputParse($input)
     {
-        $resource = fopen('php://input', 'r');
-        $util = new Service();
         $this->expectException('\Sabre\Xml\ParseException');
         $this->expectExceptionMessage('The input element to parse is empty. Do not attempt to parse');
-        $util->parse($resource, '/sabre.io/ns');
+
+        $util = new Service();
+        $util->parse($input, '/sabre.io/ns');
     }
 
     /**
@@ -105,14 +110,18 @@ XML;
         );
     }
 
-    public function testEmptyInputExpect()
+    /**
+     * @dataProvider providesEmptyInput
+     *
+     * @param string|resource $input
+     */
+    public function testEmptyInputExpect($input)
     {
-        //$resource = \fopen('')
-        $resource = fopen('php://input', 'r');
-        $util = new Service();
         $this->expectException('\Sabre\Xml\ParseException');
         $this->expectExceptionMessage('The input element to parse is empty. Do not attempt to parse');
-        $util->expect('foo', $resource, '/sabre.io/ns');
+
+        $util = new Service();
+        $util->expect('foo', $input, '/sabre.io/ns');
     }
 
     /**
@@ -348,6 +357,15 @@ XML;
     {
         $this->expectException(\InvalidArgumentException::class);
         Service::parseClarkNotation('http://sabredav.org/ns}elem');
+    }
+
+    public function providesEmptyInput()
+    {
+        $emptyResource = fopen('php://input', 'r');
+        $data[] = [$emptyResource];
+        $data[] = [''];
+
+        return $data;
     }
 
     public function providesEmptyPropfinds()


### PR DESCRIPTION
PR https://github.com/sabre-io/xml/pull/166 is incomplete. It still allows this situation to happen in an infinite loop:

```
XMLReader::XML(): Empty string supplied as input at \/Users\/mrow4a\/Projects\/www\/octest\/lib\/composer\/sabre\/xml\/lib\/Reader.php#63
XMLReader::read(): Load Data before trying to read at \/Users\/mrow4a\/Projects\/www\/octest\/lib\/composer\/sabre\/xml\/lib\/Reader.php#63
XMLReader::read(): Load Data before trying to read at \/Users\/mrow4a\/Projects\/www\/octest\/lib\/composer\/sabre\/xml\/lib\/Reader.php#63
...
```

With this MR, now I see exception properly handled:
```
Exception: {\"Exception\":\"Sabre\\\\
Xml\\\\ParseException\",\"Message\":\"The input element to parse is empty. Do not attempt to parse\",\"Code\":0,\"Trace\":\"#0 \\\/Users\\\/mrow4a\\\/Projects\\\/www\\\/octest\\\/lib\\\/composer\\\/sabre\
\\/dav\\\/lib\\\/DAV\\\/Client.php(419)
```