### PR TITLE
Test with PHP8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ env:
 
 matrix:
   include:
+    - name: 'PHP8'
+      dist: focal
+      php: nightly
+      env:
+        - RUN_PHPCSFIXER="FALSE"
+        - REPORT_COVERAGE="FALSE"
     - name: 'PHPStan'
       php: 7.4
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ php:
 
 env:
   global:
+    - RUN_PHPCSFIXER="TRUE"
+    - RUN_PHPUNIT="TRUE"
     - RUN_PHPSTAN="FALSE"
   matrix:
     - PREFER_LOWEST="" REPORT_COVERAGE="TRUE" WITH_COVERAGE="--coverage-clover=coverage.xml"
@@ -18,6 +20,8 @@ matrix:
     - name: 'PHPStan'
       php: 7.4
       env:
+        - RUN_PHPCSFIXER="FALSE"
+        - RUN_PHPUNIT="FALSE"
         - RUN_PHPSTAN="TRUE"
         - REPORT_COVERAGE="FALSE"
   fast_finish: true
@@ -27,11 +31,12 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
+  - if [ $RUN_PHPCSFIXER == "FALSE" ]; then composer remove --dev friendsofphp/php-cs-fixer; fi
   - composer update $PREFER_LOWEST
 
 script:
-  - if [ $RUN_PHPSTAN == "FALSE" ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi
-  - if [ $RUN_PHPSTAN == "FALSE" ]; then php vendor/bin/phpunit --configuration tests/phpunit.xml $WITH_COVERAGE; fi
+  - if [ $RUN_PHPCSFIXER == "TRUE" ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi
+  - if [ $RUN_PHPUNIT == "TRUE" ]; then php vendor/bin/phpunit --configuration tests/phpunit.xml $WITH_COVERAGE; fi
   - if [ $RUN_PHPSTAN == "TRUE" ]; then composer phpstan; fi
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage" : "https://sabre.io/xml/",
     "license" : "BSD-3-Clause",
     "require" : {
-        "php" : "^7.1",
+        "php" : "^7.1 || ^8.0",
         "ext-xmlwriter" : "*",
         "ext-xmlreader" : "*",
         "ext-dom" : "*",

--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -55,6 +55,7 @@ class Reader extends XMLReader
      */
     public function parse(): array
     {
+        $previousEntityState = null;
         $shouldCallLibxmlDisableEntityLoader = (\PHP_VERSION_ID < 80000);
         if ($shouldCallLibxmlDisableEntityLoader) {
             $previousEntityState = libxml_disable_entity_loader(true);

--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -55,7 +55,10 @@ class Reader extends XMLReader
      */
     public function parse(): array
     {
-        $previousEntityState = libxml_disable_entity_loader(true);
+        $shouldCallLibxmlDisableEntityLoader = (\PHP_VERSION_ID < 80000);
+        if ($shouldCallLibxmlDisableEntityLoader) {
+            $previousEntityState = libxml_disable_entity_loader(true);
+        }
         $previousSetting = libxml_use_internal_errors(true);
 
         try {
@@ -78,7 +81,9 @@ class Reader extends XMLReader
             }
         } finally {
             libxml_use_internal_errors($previousSetting);
-            libxml_disable_entity_loader($previousEntityState);
+            if ($shouldCallLibxmlDisableEntityLoader) {
+                libxml_disable_entity_loader($previousEntityState);
+            }
         }
 
         return $result;


### PR DESCRIPTION
1) sort out variables in `.travis.yml` for selecting to run php-cs-fixer, phpunit and phpstan
2) Add a matrix entry to run just phpunit on Ubuntu 20.04 "focal" with "nightly" PHP (which is the way to get PHP 8.0 at the moment)
3) When not running php-cs-fixer, explicitly remove it from `composer.json` (because php-cs-fixer does not yet support PHP 8.0, so composer cannot sort out dependencies if we have PHP 8.0 and php-cs-fixer 2.* together)
4) `libxml_disable_entity_loader` is deprecated on PHP 8.0. This is already disabled on PHP 8.0, so this function does not need to be called. Put a conditional check around it. https://php.watch/versions/8.0/libxml_disable_entity_loader-deprecation

Relates to https://github.com/sabre-io/vobject/pull/513