### PR TITLE
Changelog and Version.php for 2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ChangeLog
 =========
 
+2.2.3 (2020-10-03)
+------------------
+* #191: add changelog and version bump that was missed in 2.2.2
+
 2.2.2 (2020-10-03)
 ------------------
 * #190: adjust libxml_disable_entity_loader calls ready for PHP 8.0 (@phil-davis)

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    const VERSION = '2.2.2';
+    const VERSION = '2.2.3';
 }


### PR DESCRIPTION
I forgot to do the changelog and `Version.php` bump before making the release for 2.2.2 - so 2.2.2 as `2.2.1` in `Version.php`

Fix this by making a 2.2.3 release that will have all the Changelog entries and will have `2.2.3` in `Version.php` - that will give a consistent/tidy release. It does not hurt that there will be 2.2.2 release then 2.2.3 an hour later.