### PR TITLE
Use latest php-cs-fixer 2.17.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.16.7",
+        "friendsofphp/php-cs-fixer": "~2.17.1",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0"
     },

--- a/lib/ParseException.php
+++ b/lib/ParseException.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Sabre\Xml;
 
-use
-    Exception;
+use Exception;
 
 /**
  * This is a base exception for any exception related to parsing xml files.

--- a/tests/Sabre/Xml/Deserializer/FunctionCallerTest.php
+++ b/tests/Sabre/Xml/Deserializer/FunctionCallerTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Sabre\Xml\Deserializer;
 
-use
-    Sabre\Xml\Reader;
+use Sabre\Xml\Reader;
 
 class FunctionCallerTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/Xml/Deserializer/KeyValueTest.php
+++ b/tests/Sabre/Xml/Deserializer/KeyValueTest.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Sabre\Xml\Deserializer;
 
 use Sabre\Xml\LibXMLException;
-use
-    Sabre\Xml\Reader;
+use Sabre\Xml\Reader;
 
 class KeyValueTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Sabre/Xml/Deserializer/ValueObjectTest.php
+++ b/tests/Sabre/Xml/Deserializer/ValueObjectTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Sabre\Xml\Deserializer;
 
-use
-    Sabre\Xml\Reader;
+use Sabre\Xml\Reader;
 
 class ValueObjectTest extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
The latest php-cs-fixer finds some new things. Code changes were needed in https://github.com/sabre-io/dav/pull/1316 for `sabre/dav`. We might as well consistently make sure to use at least this version 2.17.1 in all repos so that we are doing consistent code-style checking.
