### PR TITLE
Adjust new things from cs-fixer and phpstan

### DIFF
--- a/lib/Deserializer/functions.php
+++ b/lib/Deserializer/functions.php
@@ -145,6 +145,7 @@ function keyValue(Reader $reader, string $namespace = null): array
  * ];
  *
  * @return string[]
+ *
  * @phpstan-return list<string>
  */
 function enum(Reader $reader, string $namespace = null): array
@@ -195,6 +196,7 @@ function enum(Reader $reader, string $namespace = null): array
  * @template C of object
  *
  * @param class-string<C> $className
+ *
  * @phpstan-return C
  */
 function valueObject(Reader $reader, string $className, string $namespace): object

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,16 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: lib/Deserializer/functions.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: lib/Deserializer/functions.php
-
-		-
 			message: "#^Parameter \\#3 \\$namespace of method XMLWriter\\:\\:startElementNs\\(\\) expects string, null given\\.$#"
 			count: 1
 			path: lib/Writer.php


### PR DESCRIPTION
cs-fixer now finds a bit of PHP-doc to adjust.

phpstan no longer reports some false-positives - remove them from `ignoreErrors`