### PR TITLE
Cleanup grammar in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ ChangeLog
 2.2.1 (2020-05-11)
 ------------------
 
-* #183: fixed warning 'xml cannot be empty while reading', which might lead to a infinite-loop (@mrow4a)
+* #183: fixed warning 'xml cannot be empty while reading', which might lead to an infinite-loop (@mrow4a)
 * #179, #178, #177 #176: several build/continuous integration related improvements (@phil-davis)
 
 2.2.0 (2020-01-31)
@@ -37,7 +37,7 @@ ChangeLog
 * #171: Added Support for PHP 7.4, dropped Support for PHP 7.0 (@staabm, @phil-davis)
 * #174: Update testsuite to phpunit8 (@phil-davis)
 * Added phpstan coverage (@phil-davis)
-* #144: Added a new `functionCaller` deserializer function for executing a callable when reading a XML
+* #144: Added a new `functionCaller` deserializer function for executing a callable when reading an XML
 element (@vsouz4)
 
 
@@ -237,7 +237,7 @@ element (@vsouz4)
 ------------------
 
 * #16: Added ability to override `elementMap`, `namespaceMap` and `baseUri` for
-  a fragment of a document during reading an writing using `pushContext` and
+  a fragment of a document during reading and writing using `pushContext` and
   `popContext`.
 * Removed: `Writer::$context` and `Reader::$context`.
 * #15: Added `Reader::$baseUri` to match `Writer::$baseUri`.

--- a/lib/ContextStackTrait.php
+++ b/lib/ContextStackTrait.php
@@ -63,7 +63,7 @@ trait ContextStackTrait
      * The writer may use this if you attempt to serialize an object with a
      * class that does not implement XmlSerializable.
      *
-     * Instead it will look at this classmap to see if there is a custom
+     * Instead, it will look at this classmap to see if there is a custom
      * serializer here. This is useful if you don't want your value objects
      * to be responsible for serializing themselves.
      *

--- a/lib/Deserializer/functions.php
+++ b/lib/Deserializer/functions.php
@@ -187,7 +187,7 @@ function enum(Reader $reader, string $namespace = null): array
 }
 
 /**
- * The valueObject deserializer turns an xml element into a PHP object of
+ * The valueObject deserializer turns an XML element into a PHP object of
  * a specific class.
  *
  * This is primarily used by the mapValueObject function from the Service
@@ -256,7 +256,7 @@ function valueObject(Reader $reader, string $className, string $namespace): obje
  *
  * The repeatingElements deserializer simply returns everything as an array.
  *
- * $childElementName must either be a a clark-notation element name, or if no
+ * $childElementName must either be a clark-notation element name, or if no
  * namespace is used, the bare element name.
  *
  * @phpstan-return list<mixed>
@@ -280,7 +280,7 @@ function repeatingElements(Reader $reader, string $childElementName): array
 /**
  * This deserializer helps you to deserialize structures which contain mixed content.
  *
- * <p>some text <extref>and a inline tag</extref>and even more text</p>
+ * <p>some text <extref>and an inline tag</extref>and even more text</p>
  *
  * The above example will return
  *
@@ -288,13 +288,13 @@ function repeatingElements(Reader $reader, string $childElementName): array
  *     'some text',
  *     [
  *         'name'       => '{}extref',
- *         'value'      => 'and a inline tag',
+ *         'value'      => 'and an inline tag',
  *         'attributes' => []
  *     ],
  *     'and even more text'
  * ]
  *
- * In strict XML documents you wont find this kind of markup but in html this is a quite common pattern.
+ * In strict XML documents you won't find this kind of markup but in html this is a quite common pattern.
  *
  * @return array<mixed>
  */
@@ -330,7 +330,7 @@ function mixedContent(Reader $reader): array
 }
 
 /**
- * The functionCaller deserializer turns an xml element into whatever your callable return.
+ * The functionCaller deserializer turns an XML element into whatever your callable return.
  *
  * You can use, e.g., a named constructor (factory method) to create an object using
  * this function.

--- a/lib/Serializer/functions.php
+++ b/lib/Serializer/functions.php
@@ -48,7 +48,7 @@ function enum(Writer $writer, array $values): void
 /**
  * The valueObject serializer turns a simple PHP object into a classname.
  *
- * Every public property will be encoded as an xml element with the same
+ * Every public property will be encoded as an XML element with the same
  * name, in the XML namespace as specified.
  *
  * Values that are set to null or an empty array are not serialized. To

--- a/lib/Service.php
+++ b/lib/Service.php
@@ -46,7 +46,7 @@ class Service
      * The writer may use this if you attempt to serialize an object with a
      * class that does not implement XmlSerializable.
      *
-     * Instead it will look at this classmap to see if there is a custom
+     * Instead, it will look at this classmap to see if there is a custom
      * serializer here. This is useful if you don't want your value objects
      * to be responsible for serializing themselves.
      *


### PR DESCRIPTION
No functional change. This just cleans up some crud in comments that my IDE keeps telling me about. May as well do it so I don't have to see it any more.