### PR TITLE
Allow sabre/uri major version 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ext-xmlreader" : "*",
         "ext-dom" : "*",
         "lib-libxml" : ">=2.6.20",
-        "sabre/uri" : ">=1.0,<4.0.0"
+        "sabre/uri" : ">=2.0,<4.0.0"
     },
     "authors" : [
         {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ext-xmlreader" : "*",
         "ext-dom" : "*",
         "lib-libxml" : ">=2.6.20",
-        "sabre/uri" : ">=1.0,<3.0.0"
+        "sabre/uri" : ">=1.0,<4.0.0"
     },
     "authors" : [
         {


### PR DESCRIPTION
`sabre/xml` 3 already requires PHP 7.4 or later. So anyone who gets "given" `sabre/xml` 3 by composer has at least PHP 7.4.

`        "sabre/uri" : ">=1.0,<4.0.0"`
1) Is there any good reason to keep the mention of `sabre/uri` 1.0? It feels a bit odd to keep allowing people to use such an old version of `sabre/uri` with `sabre/xml`

Answer: dropped.

2) What version bump should we do in `sabre/xml` when we release this change - I guess someone might notice the Windows file path behavior change in `sabre/uri` if they auto-magically get the new major version. But they can also easily mention `sabre/uri` major version 2 in their own `composer.json` if they themselves depend on `sabre/uri` - so is the next `sabre/xml` just a patch, a minor or a major release?

Answer: I will release a new major version, to be safe.