### PR TITLE
Prepare release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ChangeLog
 =========
 
+4.0.0 (2022-09-26)
+------------------
+* #226 Allow sabre/uri major version 3 ( @phil-davis )
+
 3.0.0 (2022-08-17)
 ------------------
 * #220 Set minimum PHP to 7.4 and declare types ( @phil-davis )

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '3.0.0';
+    public const VERSION = '4.0.0';
 }


### PR DESCRIPTION
`sabre/uri` major version 3 has a breaking change (which only applies to Windows-style URIs, but it is breaking for an installation that really uses that). So bump the major version here in `sabre/xml` so that consumers can choose exactly what combination of `sabre/xml` plus `sabre/uri` that they use.

It's a bit sad that I released 3.0.0 only a month ago, but the numbers are integers, and integers go on forever - we won't run out!