### PR TITLE
Adjust code style to meet current php-cs-fixer

### DIFF
--- a/lib/LibXMLException.php
+++ b/lib/LibXMLException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sabre\Xml;
 
 use LibXMLError;
-use Throwable;
 
 /**
  * This exception is thrown when the Reader runs into a parsing error.
@@ -30,9 +29,9 @@ class LibXMLException extends ParseException
      *
      * You should pass a list of LibXMLError objects in its constructor.
      *
-     * @param LibXMLError[] $errors
+     * @param \LibXMLError[] $errors
      */
-    public function __construct(array $errors, int $code = 0, Throwable $previousException = null)
+    public function __construct(array $errors, int $code = 0, \Throwable $previousException = null)
     {
         $this->errors = $errors;
         parent::__construct($errors[0]->message.' on line '.$errors[0]->line.', column '.$errors[0]->column, $code, $previousException);
@@ -41,7 +40,7 @@ class LibXMLException extends ParseException
     /**
      * Returns the LibXML errors.
      *
-     * @return LibXMLError[]
+     * @return \LibXMLError[]
      */
     public function getErrors(): array
     {

--- a/lib/ParseException.php
+++ b/lib/ParseException.php
@@ -13,6 +13,6 @@ use Exception;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class ParseException extends Exception
+class ParseException extends \Exception
 {
 }

--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -19,7 +19,7 @@ use XMLReader;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class Reader extends XMLReader
+class Reader extends \XMLReader
 {
     use ContextStackTrait;
 
@@ -211,7 +211,7 @@ class Reader extends XMLReader
         $previousDepth = $this->depth;
 
         while ($this->read() && $this->depth != $previousDepth) {
-            if (in_array($this->nodeType, [XMLReader::TEXT, XMLReader::CDATA, XMLReader::WHITESPACE])) {
+            if (in_array($this->nodeType, [\XMLReader::TEXT, \XMLReader::CDATA, \XMLReader::WHITESPACE])) {
                 $result .= $this->value;
             }
         }

--- a/lib/Serializer/functions.php
+++ b/lib/Serializer/functions.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\Xml\Serializer;
 
-use InvalidArgumentException;
 use Sabre\Xml\Writer;
 use Sabre\Xml\XmlSerializable;
 
@@ -197,12 +196,12 @@ function standardSerializer(Writer $writer, $value): void
                 $writer->write($item);
                 $writer->endElement();
             } else {
-                throw new InvalidArgumentException('The writer does not know how to serialize arrays with keys of type: '.gettype($name));
+                throw new \InvalidArgumentException('The writer does not know how to serialize arrays with keys of type: '.gettype($name));
             }
         }
     } elseif (is_object($value)) {
-        throw new InvalidArgumentException('The writer cannot serialize objects of class: '.get_class($value));
+        throw new \InvalidArgumentException('The writer cannot serialize objects of class: '.get_class($value));
     } elseif (!is_null($value)) {
-        throw new InvalidArgumentException('The writer cannot serialize values of type: '.gettype($value));
+        throw new \InvalidArgumentException('The writer cannot serialize values of type: '.gettype($value));
     }
 }

--- a/lib/Writer.php
+++ b/lib/Writer.php
@@ -30,7 +30,7 @@ use XMLWriter;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class Writer extends XMLWriter
+class Writer extends \XMLWriter
 {
     use ContextStackTrait;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: "#^Parameter \\#3 \\$namespace of method XMLWriter\\:\\:startElementNs\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: lib/Writer.php

--- a/tests/Sabre/Xml/ContextStack.php
+++ b/tests/Sabre/Xml/ContextStack.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace Sabre\Xml;
 
-use XMLReader;
-
 /**
  * This is a wrapper around ContextStackTrait to use for unit tests.
  *
  * @license http://sabre.io/license/ Modified BSD License
  */
-class ContextStack extends XMLReader
+class ContextStack extends \XMLReader
 {
     use ContextStackTrait;
 }


### PR DESCRIPTION
php-cs-fixer is reporting these. I guess there has been a newer php-cs-fixer version released that is different.

It wants "root" classes and functions to use the leading `\` - `\DateTime`.

We could change some php-cs-fixer rule settings, but actually it is easy to accept these code-style changes.