### PR TITLE
Bump require-dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,9 +44,9 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.9",
-        "phpstan/phpstan": "^1.8",
-        "phpunit/phpunit" : "^9.0"
+        "friendsofphp/php-cs-fixer": "^3.14",
+        "phpstan/phpstan": "^1.9",
+        "phpunit/phpunit" : "^9.6"
     },
     "scripts": {
         "phpstan": [

--- a/lib/Element/Uri.php
+++ b/lib/Element/Uri.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Sabre\Xml\Element;
 
-use function Sabre\Uri\resolve;
-
 use Sabre\Xml;
+
+use function Sabre\Uri\resolve;
 
 /**
  * Uri element.


### PR DESCRIPTION
I really just want to check that all of CI still passes (there have been minor version releases of the CI tools phpunit, phpstan and php-cs-fixer recently).

This PR updates the minor versions recorded in `composer.json`. That does not do anything exciting, but maybe it helps in the future that we know what minor version of each tool was known to work.