### PR TITLE
Bump dependency versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.17",
+        "friendsofphp/php-cs-fixer": "^3.19",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit" : "^9.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.19",
+        "friendsofphp/php-cs-fixer": "^3.20",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit" : "^9.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,8 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.14",
-        "phpstan/phpstan": "^1.9",
+        "friendsofphp/php-cs-fixer": "^3.17",
+        "phpstan/phpstan": "^1.10",
         "phpunit/phpunit" : "^9.6"
     },
     "scripts": {

--- a/lib/Deserializer/functions.php
+++ b/lib/Deserializer/functions.php
@@ -330,12 +330,12 @@ function mixedContent(Reader $reader): array
 }
 
 /**
- * The functionCaller deserializer turns an XML element into whatever your callable return.
+ * The functionCaller deserializer turns an XML element into whatever your callable returns.
  *
  * You can use, e.g., a named constructor (factory method) to create an object using
  * this function.
  *
- * @return mixed
+ * @return mixed whatever the 'func' callable returns
  */
 function functionCaller(Reader $reader, callable $func, string $namespace)
 {

--- a/lib/Element/Base.php
+++ b/lib/Element/Base.php
@@ -20,16 +20,14 @@ use Sabre\Xml;
 class Base implements Xml\Element
 {
     /**
-     * PHP value to serialize.
-     *
-     * @var mixed
+     * @var mixed PHP value to serialize
      */
     protected $value;
 
     /**
      * Constructor.
      *
-     * @param mixed $value
+     * @param mixed $value PHP value to serialize
      */
     public function __construct($value = null)
     {
@@ -75,7 +73,7 @@ class Base implements Xml\Element
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @return mixed
+     * @return array<string, mixed>|string|null
      */
     public static function xmlDeserialize(Xml\Reader $reader)
     {

--- a/lib/ParseException.php
+++ b/lib/ParseException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\Xml;
 
-use Exception;
-
 /**
  * This is a base exception for any exception related to parsing xml files.
  *

--- a/lib/Service.php
+++ b/lib/Service.php
@@ -260,7 +260,7 @@ class Service
      * The ValueObject must have been previously registered using
      * mapValueObject().
      *
-     *@throws \InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     public function writeValueObject(object $object, string $contextUri = null): string
     {

--- a/lib/Writer.php
+++ b/lib/Writer.php
@@ -92,7 +92,7 @@ class Writer extends \XMLWriter
      *    ]
      * ]
      *
-     * @param mixed $value
+     * @param mixed $value PHP value to be written
      */
     public function write($value): void
     {

--- a/lib/XmlDeserializable.php
+++ b/lib/XmlDeserializable.php
@@ -32,7 +32,7 @@ interface XmlDeserializable
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      *
-     * @return mixed
+     * @return mixed see comments above
      */
     public static function xmlDeserialize(Reader $reader);
 }

--- a/tests/Sabre/Xml/Element/Eater.php
+++ b/tests/Sabre/Xml/Element/Eater.php
@@ -52,8 +52,6 @@ class Eater implements Xml\Element
      *
      * $reader->parseSubTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @return mixed
      */
     public static function xmlDeserialize(Xml\Reader $reader)
     {

--- a/tests/Sabre/Xml/Element/Mock.php
+++ b/tests/Sabre/Xml/Element/Mock.php
@@ -44,8 +44,6 @@ class Mock implements Xml\Element
      *
      * $reader->parseSubTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @return mixed
      */
     public static function xmlDeserialize(Xml\Reader $reader)
     {

--- a/tests/Sabre/Xml/Element/XmlFragmentTest.php
+++ b/tests/Sabre/Xml/Element/XmlFragmentTest.php
@@ -111,7 +111,7 @@ BLA;
     /**
      * @dataProvider xmlProvider
      */
-    public function testSerialize(string $expectedFallback, string $input, ?string $expected = null): void
+    public function testSerialize(string $expectedFallback, string $input, string $expected = null): void
     {
         if (is_null($expected)) {
             $expected = $expectedFallback;


### PR DESCRIPTION
Adjust PHP doc etc. so that the latest php-cs-fixer and phpstan will pass.
Mostly cs-fixer removed various `mixed` type declarations for var, param, return. But then `phpstan` complained about things having their type declaration missing!

One workaround is to also put a description at the end of the type declaration. So I did that in some places.

I also specified the type better in one place.