### PR TITLE
[2.2] Fixed error where valueobject has eaten too much

### DIFF
--- a/lib/Deserializer/functions.php
+++ b/lib/Deserializer/functions.php
@@ -216,7 +216,7 @@ function valueObject(Reader $reader, string $className, string $namespace)
                 $reader->next();
             }
         } else {
-            if (!$reader->read()) {
+            if (Reader::END_ELEMENT !== $reader->nodeType && !$reader->read()) {
                 break;
             }
         }

--- a/tests/Sabre/Xml/Deserializer/ValueObjectTest.php
+++ b/tests/Sabre/Xml/Deserializer/ValueObjectTest.php
@@ -153,6 +153,39 @@ XML;
             $output
         );
     }
+
+    public function testDeserializeValueObjectEmptyString(): void
+    {
+        $input = <<<XML
+<?xml version="1.0"?>
+<doc>
+<foo xmlns="urn:foo"></foo>
+</doc>
+XML;
+
+        $reader = new Reader();
+        $reader->xml($input);
+        $reader->elementMap = [
+            '{urn:foo}foo' => function (Reader $reader) {
+                return valueObject($reader, 'Sabre\\Xml\\Deserializer\\TestVo', 'urn:foo');
+            },
+        ];
+
+        $output = $reader->parse();
+
+        $vo = new TestVo();
+
+        $expected = [
+            'name' => '{urn:foo}foo',
+            'value' => $vo,
+            'attributes' => [],
+        ];
+
+        $this->assertEquals(
+            $expected,
+            $output['value'][0]
+        );
+    }
 }
 
 class TestVo


### PR DESCRIPTION
This fixes a bug, when valueobject is an empty element like <foo></foo> In this situation the deserializer did read one more, thus ending up a level higher than required

Backport #229 to 2.2 branch