### PR TITLE
Enhance PHPdoc of Service write value parameter

### DIFF
--- a/lib/Service.php
+++ b/lib/Service.php
@@ -198,7 +198,7 @@ class Service
      * This allows an implementor to easily create URI's relative to the root
      * of the domain.
      *
-     * @param string|array<string, mixed>|object|XmlSerializable $value
+     * @param string|array<int|string, mixed>|object|XmlSerializable $value
      */
     public function write(string $rootElementName, $value, string $contextUri = null): string
     {


### PR DESCRIPTION
Fixes #237 

This makes the PHPdoc of Service write allow an array with integer keys to be passed in the `value` parameter.
That is passed to:
`$w->writeElement($rootElementName, $value);`

And Writer `writeElement` already has PHPdoc that allows `array<int|string, mixed>`