### PR TITLE
fix: return type of XmlFragment::xmlDeserialize to match base declara…

### DIFF
--- a/lib/Element/XmlFragment.php
+++ b/lib/Element/XmlFragment.php
@@ -134,7 +134,7 @@ XML;
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
      */
-    public static function xmlDeserialize(Reader $reader): XmlFragment
+    public static function xmlDeserialize(Reader $reader)
     {
         $result = new self($reader->readInnerXml());
         $reader->next();


### PR DESCRIPTION
…tion

XmlDeserializable::xmlDeserialize has no return type defined as well and any sub-class of XmlFragment will also return mixed - see various xml classes in sabre/dav

refs https://github.com/sabre-io/xml/blob/4689ae198bb1ab9a2598720a2ccfc7963210b06b/lib/XmlDeserializable.php#L37