### PR TITLE
Fixed handling of elements from foreign namespaces in values object (2.2)

### DIFF
--- a/lib/Deserializer/functions.php
+++ b/lib/Deserializer/functions.php
@@ -215,6 +215,9 @@ function valueObject(Reader $reader, string $className, string $namespace)
                 // Ignore property
                 $reader->next();
             }
+        } elseif (Reader::ELEMENT === $reader->nodeType) {
+            // Skipping element from different namespace
+            $reader->next();
         } else {
             if (Reader::END_ELEMENT !== $reader->nodeType && !$reader->read()) {
                 break;

--- a/tests/Sabre/Xml/Deserializer/ValueObjectTest.php
+++ b/tests/Sabre/Xml/Deserializer/ValueObjectTest.php
@@ -81,6 +81,44 @@ XML;
         );
     }
 
+    public function testDeserializeValueObjectIgnoredNamespace()
+    {
+        $input = <<<XML
+<?xml version="1.0"?>
+<foo xmlns="urn:foo" xmlns:alien="urn:example.com">
+   <firstName>Harry</firstName>
+   <alien:email>harry@example.org</alien:email>
+   <lastName>Turtle</lastName>
+</foo>
+XML;
+
+        $reader = new Reader();
+        $reader->xml($input);
+        $reader->elementMap = [
+            '{urn:foo}foo' => function (Reader $reader) {
+                return valueObject($reader, 'Sabre\\Xml\\Deserializer\\TestVo', 'urn:foo');
+            },
+        ];
+
+        $output = $reader->parse();
+
+        $vo = new TestVo();
+        $vo->firstName = 'Harry';
+        $vo->lastName = 'Turtle';
+
+        $expected = [
+            'name' => '{urn:foo}foo',
+            'value' => $vo,
+            'attributes' => [],
+        ];
+
+        $this->assertEquals(
+            $expected,
+            $output
+        );
+    }
+
+
     public function testDeserializeValueObjectAutoArray()
     {
         $input = <<<XML

--- a/tests/Sabre/Xml/Deserializer/ValueObjectTest.php
+++ b/tests/Sabre/Xml/Deserializer/ValueObjectTest.php
@@ -118,7 +118,6 @@ XML;
         );
     }
 
-
     public function testDeserializeValueObjectAutoArray()
     {
         $input = <<<XML


### PR DESCRIPTION
When encountering an element from another namespace the value object parser does skip the opening element. However when it encounters the closing element it did handle it like it was the closing element of the one being processed.

This commit and unit test fixes the issue by ignoring the element completely. Without the patch the unit test would not parse the `lastName` element.

This patch is against the branch `2.2`, because I'm still using this one, I hope it's not a problem. I've checked the `master` branch as well, and it should be straightforward to apply it there as well.

BTW: would it be possible to add mappings for multiple namespaces?