### PR TITLE
chore: use php-cs-fixer 3.49

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.49",
+        "friendsofphp/php-cs-fixer": "^3.51",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit" : "^9.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.38",
+        "friendsofphp/php-cs-fixer": "^3.49",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit" : "^9.6"
     },

--- a/lib/Deserializer/functions.php
+++ b/lib/Deserializer/functions.php
@@ -57,7 +57,7 @@ use Sabre\Xml\Reader;
  *
  * @phpstan-return array<string, mixed>
  */
-function keyValue(Reader $reader, string $namespace = null): array
+function keyValue(Reader $reader, ?string $namespace = null): array
 {
     // If there's no children, we don't do anything.
     if ($reader->isEmptyElement) {
@@ -148,7 +148,7 @@ function keyValue(Reader $reader, string $namespace = null): array
  *
  * @phpstan-return list<string>
  */
-function enum(Reader $reader, string $namespace = null): array
+function enum(Reader $reader, ?string $namespace = null): array
 {
     // If there's no children, we don't do anything.
     if ($reader->isEmptyElement) {

--- a/lib/LibXMLException.php
+++ b/lib/LibXMLException.php
@@ -31,7 +31,7 @@ class LibXMLException extends ParseException
      *
      * @param \LibXMLError[] $errors
      */
-    public function __construct(array $errors, int $code = 0, \Throwable $previousException = null)
+    public function __construct(array $errors, int $code = 0, ?\Throwable $previousException = null)
     {
         $this->errors = $errors;
         parent::__construct($errors[0]->message.' on line '.$errors[0]->line.', column '.$errors[0]->column, $code, $previousException);

--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -107,7 +107,7 @@ class Reader extends \XMLReader
      *
      * @return array<int,array<string, mixed>>
      */
-    public function parseGetElements(array $elementMap = null): array
+    public function parseGetElements(?array $elementMap = null): array
     {
         $result = $this->parseInnerTree($elementMap);
         if (!is_array($result)) {
@@ -132,7 +132,7 @@ class Reader extends \XMLReader
      *
      * @return array<int,array<string, mixed>>|string|null
      */
-    public function parseInnerTree(array $elementMap = null)
+    public function parseInnerTree(?array $elementMap = null)
     {
         $text = null;
         $elements = [];

--- a/lib/Service.php
+++ b/lib/Service.php
@@ -107,7 +107,7 @@ class Service
      *
      * @throws ParseException
      */
-    public function parse($input, string $contextUri = null, string &$rootElementName = null)
+    public function parse($input, ?string $contextUri = null, ?string &$rootElementName = null)
     {
         if (is_resource($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
@@ -151,7 +151,7 @@ class Service
      *
      * @throws ParseException
      */
-    public function expect($rootElementName, $input, string $contextUri = null)
+    public function expect($rootElementName, $input, ?string $contextUri = null)
     {
         if (is_resource($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
@@ -200,7 +200,7 @@ class Service
      *
      * @param string|array<int|string, mixed>|object|XmlSerializable $value
      */
-    public function write(string $rootElementName, $value, string $contextUri = null): string
+    public function write(string $rootElementName, $value, ?string $contextUri = null): string
     {
         $w = $this->getWriter();
         $w->openMemory();
@@ -263,7 +263,7 @@ class Service
      *
      * @throws \InvalidArgumentException
      */
-    public function writeValueObject(object $object, string $contextUri = null): string
+    public function writeValueObject(object $object, ?string $contextUri = null): string
     {
         if (!isset($this->valueObjectMap[get_class($object)])) {
             throw new \InvalidArgumentException('"'.get_class($object).'" is not a registered value object class. Register your class with mapValueObject.');

--- a/tests/Sabre/Xml/Element/XmlFragmentTest.php
+++ b/tests/Sabre/Xml/Element/XmlFragmentTest.php
@@ -111,7 +111,7 @@ BLA;
     /**
      * @dataProvider xmlProvider
      */
-    public function testSerialize(string $expectedFallback, string $input, string $expected = null): void
+    public function testSerialize(string $expectedFallback, string $input, ?string $expected = null): void
     {
         if (is_null($expected)) {
             $expected = $expectedFallback;


### PR DESCRIPTION
php-cs-fixer 3.49 (or some recent minor release) wants to use the `?` (nullable) syntax on optional parameters.
That syntax has been supported for quite a while since PHP https://www.php.net/manual/en/migration71.new-features.php

In the cases here, as well as the default value of the parameter being `null`, the `?` explicitly allows the caller to pass the value `null` if they want.

This seems reasonable, I don't see how it can break any existing usage.