### PR TITLE
More precise `parseClarkNotation` return type

### DIFF
--- a/lib/Service.php
+++ b/lib/Service.php
@@ -241,7 +241,6 @@ class Service
     public function mapValueObject(string $elementName, string $className): void
     {
         list($namespace) = self::parseClarkNotation($elementName);
-        $namespace = $namespace ?? '';
 
         $this->elementMap[$elementName] = function (Reader $reader) use ($className, $namespace) {
             return \Sabre\Xml\Deserializer\valueObject($reader, $className, $namespace);
@@ -282,7 +281,7 @@ class Service
      *
      * If the string was invalid, it will throw an InvalidArgumentException.
      *
-     * @return array{string|null, string}
+     * @return array{string, string}
      *
      * @throws \InvalidArgumentException
      */

--- a/lib/Writer.php
+++ b/lib/Writer.php
@@ -124,7 +124,6 @@ class Writer extends \XMLWriter
         if ('{' === $name[0]) {
             list($namespace, $localName) =
                 Service::parseClarkNotation($name);
-            $namespace = $namespace ?? '';
 
             if (array_key_exists($namespace, $this->namespaceMap)) {
                 $result = $this->startElementNS(
@@ -239,7 +238,6 @@ class Writer extends \XMLWriter
             $localName
         ) = Service::parseClarkNotation($name);
 
-        $namespace = $namespace ?? '';
         if (array_key_exists($namespace, $this->namespaceMap)) {
             // It's an attribute with a namespace we know
             return $this->writeAttribute(

--- a/tests/Sabre/Xml/ServiceTest.php
+++ b/tests/Sabre/Xml/ServiceTest.php
@@ -352,18 +352,31 @@ XML;
         $service->writeValueObject(new \stdClass());
     }
 
-    public function testParseClarkNotation(): void
+    /**
+     * @param array<string> $expected
+     *
+     * @dataProvider provideParseClarkNotationInput
+     */
+    public function testParseClarkNotation(string $clark, array $expected): void
     {
-        self::assertEquals([
-            'http://sabredav.org/ns',
-            'elem',
-        ], Service::parseClarkNotation('{http://sabredav.org/ns}elem'));
+        self::assertEquals($expected, Service::parseClarkNotation($clark));
     }
 
     public function testParseClarkNotationFail(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         Service::parseClarkNotation('http://sabredav.org/ns}elem');
+    }
+
+    /**
+     * @return array<int, list{string, array<string>}>
+     */
+    public function provideParseClarkNotationInput(): iterable
+    {
+        return [
+            ['{http://sabredav.org/ns}elem', ['http://sabredav.org/ns', 'elem']],
+            ['{}elem', ['', 'elem']],
+        ];
     }
 
     /**


### PR DESCRIPTION
while updating from a old version I got the impression that the first offset of `parseClarkNotation` cannot get null.

https://3v4l.org/Bo8q3

did I miss something?