### PR TITLE
Fixed handling of elements from foreign namespaces in values object (master)

### DIFF
--- a/lib/Deserializer/functions.php
+++ b/lib/Deserializer/functions.php
@@ -223,6 +223,9 @@ function valueObject(Reader $reader, string $className, string $namespace): obje
                 // Ignore property
                 $reader->next();
             }
+        } elseif (Reader::ELEMENT === $reader->nodeType) {
+            // Skipping element from different namespace
+            $reader->next();
         } else {
             if (Reader::END_ELEMENT !== $reader->nodeType && !$reader->read()) {
                 break;

--- a/tests/Sabre/Xml/Deserializer/ValueObjectTest.php
+++ b/tests/Sabre/Xml/Deserializer/ValueObjectTest.php
@@ -82,6 +82,43 @@ XML;
         );
     }
 
+    public function testDeserializeValueObjectIgnoredNamespace(): void
+    {
+        $input = <<<XML
+<?xml version="1.0"?>
+<foo xmlns="urn:foo" xmlns:alien="urn:example.com">
+   <firstName>Harry</firstName>
+   <alien:email>harry@example.org</alien:email>
+   <lastName>Turtle</lastName>
+</foo>
+XML;
+
+        $reader = new Reader();
+        $reader->xml($input);
+        $reader->elementMap = [
+            '{urn:foo}foo' => function (Reader $reader) {
+                return valueObject($reader, 'Sabre\\Xml\\Deserializer\\TestVo', 'urn:foo');
+            },
+        ];
+
+        $output = $reader->parse();
+
+        $vo = new TestVo();
+        $vo->firstName = 'Harry';
+        $vo->lastName = 'Turtle';
+
+        $expected = [
+            'name' => '{urn:foo}foo',
+            'value' => $vo,
+            'attributes' => [],
+        ];
+
+        $this->assertEquals(
+            $expected,
+            $output
+        );
+    }
+
     public function testDeserializeValueObjectAutoArray(): void
     {
         $input = <<<XML


### PR DESCRIPTION
When encountering an element from another namespace the value object parser does skip the opening element. However when it encounters the closing element it did handle it like it was the closing element of the one being processed.

This commit and unit test fixes the issue by ignoring the element completely

Foward-port of #270 to master.

This works nicely. If I locally remove the code added to `lib/Deserializer/functions.php` and run the unit tests, the new test fails with:
```
$ composer phpunit
> phpunit --configuration tests/phpunit.xml
PHPUnit 9.6.19 by Sebastian Bergmann and contributors.

.............F.................................................  63 / 113 ( 55%)
..................................................              113 / 113 (100%)

Time: 00:00.068, Memory: 8.00 MB

There was 1 failure:

1) Sabre\Xml\Deserializer\ValueObjectTest::testDeserializeValueObjectIgnoredNamespace
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
     'name' => '{urn:foo}foo'
     'value' => Sabre\Xml\Deserializer\TestVo Object (
         'firstName' => 'Harry'
-        'lastName' => 'Turtle'
         'link' => Array ()
     )
     'attributes' => Array ()
 )

/home/phil/git/sabre-io/xml/tests/Sabre/Xml/Deserializer/ValueObjectTest.php:117
phpvfscomposer:///home/phil/git/sabre-io/xml/vendor/phpunit/phpunit/phpunit:106

FAILURES!
Tests: 113, Assertions: 147, Failures: 1.
Script phpunit --configuration tests/phpunit.xml handling the phpunit event returned with error code 1
```

'lastName' is missing, which is exactly the problem described.