### PR TITLE
Fixed handling of elements from foreign namespaces in values object (v3)

### DIFF
--- a/lib/Deserializer/functions.php
+++ b/lib/Deserializer/functions.php
@@ -223,6 +223,9 @@ function valueObject(Reader $reader, string $className, string $namespace): obje
                 // Ignore property
                 $reader->next();
             }
+        } elseif (Reader::ELEMENT === $reader->nodeType) {
+            // Skipping element from different namespace
+            $reader->next();
         } else {
             if (Reader::END_ELEMENT !== $reader->nodeType && !$reader->read()) {
                 break;

--- a/tests/Sabre/Xml/Deserializer/ValueObjectTest.php
+++ b/tests/Sabre/Xml/Deserializer/ValueObjectTest.php
@@ -82,6 +82,43 @@ XML;
         );
     }
 
+    public function testDeserializeValueObjectIgnoredNamespace(): void
+    {
+        $input = <<<XML
+<?xml version="1.0"?>
+<foo xmlns="urn:foo" xmlns:alien="urn:example.com">
+   <firstName>Harry</firstName>
+   <alien:email>harry@example.org</alien:email>
+   <lastName>Turtle</lastName>
+</foo>
+XML;
+
+        $reader = new Reader();
+        $reader->xml($input);
+        $reader->elementMap = [
+            '{urn:foo}foo' => function (Reader $reader) {
+                return valueObject($reader, 'Sabre\\Xml\\Deserializer\\TestVo', 'urn:foo');
+            },
+        ];
+
+        $output = $reader->parse();
+
+        $vo = new TestVo();
+        $vo->firstName = 'Harry';
+        $vo->lastName = 'Turtle';
+
+        $expected = [
+            'name' => '{urn:foo}foo',
+            'value' => $vo,
+            'attributes' => [],
+        ];
+
+        $this->assertEquals(
+            $expected,
+            $output
+        );
+    }
+
     public function testDeserializeValueObjectAutoArray(): void
     {
         $input = <<<XML


### PR DESCRIPTION
When encountering an element from another namespace the value object parser does skip the opening element. However when it encounters the closing element it did handle it like it was the closing element of the one being processed.

This commit and unit test fixes the issue by ignoring the element completely

This is a port of #270 to the v3 branch.

Also see #273 which has the same code applied to the master branch.