### PR TITLE
More precise parseClarkNotation return type (v3)

### DIFF
--- a/lib/Service.php
+++ b/lib/Service.php
@@ -281,7 +281,7 @@ class Service
      *
      * If the string was invalid, it will throw an InvalidArgumentException.
      *
-     * @return array{string|null, string}
+     * @return array{string, string}
      *
      * @throws \InvalidArgumentException
      */

--- a/lib/Writer.php
+++ b/lib/Writer.php
@@ -134,7 +134,7 @@ class Writer extends \XMLWriter
             } else {
                 // An empty namespace means it's the global namespace. This is
                 // allowed, but it mustn't get a prefix.
-                if ('' === $namespace || null === $namespace) {
+                if ('' === $namespace) {
                     $result = $this->startElement($localName);
                     $this->writeAttribute('xmlns', '');
                 } else {

--- a/tests/Sabre/Xml/ServiceTest.php
+++ b/tests/Sabre/Xml/ServiceTest.php
@@ -346,18 +346,31 @@ XML;
         $service->writeValueObject(new \stdClass());
     }
 
-    public function testParseClarkNotation(): void
+    /**
+     * @param array<string> $expected
+     *
+     * @dataProvider provideParseClarkNotationInput
+     */
+    public function testParseClarkNotation(string $clark, array $expected): void
     {
-        self::assertEquals([
-            'http://sabredav.org/ns',
-            'elem',
-        ], Service::parseClarkNotation('{http://sabredav.org/ns}elem'));
+        self::assertEquals($expected, Service::parseClarkNotation($clark));
     }
 
     public function testParseClarkNotationFail(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         Service::parseClarkNotation('http://sabredav.org/ns}elem');
+    }
+
+    /**
+     * @return array<int, list{string, array<string>}>
+     */
+    public function provideParseClarkNotationInput(): iterable
+    {
+        return [
+            ['{http://sabredav.org/ns}elem', ['http://sabredav.org/ns', 'elem']],
+            ['{}elem', ['', 'elem']],
+        ];
     }
 
     /**


### PR DESCRIPTION
Backport PR #272 to v3 branch

And adjust namespace check because it cannot be null - this happened in master as part of PR #251 "Increase phpstan from level 6 to level 8". We don't want to backport all those changes to v3, but we do need this little change so that `phpstan` will pass.