### PR TITLE
chore: bump dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,8 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.51",
-        "phpstan/phpstan": "^1.10",
+        "friendsofphp/php-cs-fixer": "^3.56",
+        "phpstan/phpstan": "^1.11",
         "phpunit/phpunit" : "^9.6"
     },
     "scripts": {


### PR DESCRIPTION
`phpstan` `1.11` was released yesterday and has quite a lot of code changes. So I wanted to make sure that the code is passing with the new `phpstan`