### PR TITLE
Add PHP 8.4 compliance for 2.2 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,16 @@ jobs:
       matrix:
         php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         coverage: ['pcov']
+        code-style: ['no']
         code-analysis: ['no']
         include:
           - php-versions: '7.1'
             coverage: 'none'
+            code-style: 'yes'
+            code-analysis: 'yes'
+          - php-versions: '8.4'
+            coverage: 'pcov'
+            code-style: 'no'
             code-analysis: 'yes'
     steps:
       - name: Checkout
@@ -48,8 +54,8 @@ jobs:
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Code Analysis (PHP CS-Fixer)
-        if: matrix.code-analysis == 'yes'
-        run: php vendor/bin/php-cs-fixer fix --dry-run --diff
+        if: matrix.code-style == 'yes'
+        run: PHP_CS_FIXER_IGNORE_ENV=true php vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Code Analysis (PHPStan)
         if: matrix.code-analysis == 'yes'

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.17.1",
         "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0"
+        "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.6"
     },
     "scripts": {
         "phpstan": [

--- a/lib/LibXMLException.php
+++ b/lib/LibXMLException.php
@@ -33,7 +33,7 @@ class LibXMLException extends ParseException
      * @param LibXMLError[] $errors
      * @param Throwable     $previousException
      */
-    public function __construct(array $errors, int $code = 0, Throwable $previousException = null)
+    public function __construct(array $errors, int $code = 0, ?Throwable $previousException = null)
     {
         $this->errors = $errors;
         parent::__construct($errors[0]->message.' on line '.$errors[0]->line.', column '.$errors[0]->column, $code, $previousException);

--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -103,7 +103,7 @@ class Reader extends XMLReader
      * If the $elementMap argument is specified, the existing elementMap will
      * be overridden while parsing the tree, and restored after this process.
      */
-    public function parseGetElements(array $elementMap = null): array
+    public function parseGetElements(?array $elementMap = null): array
     {
         $result = $this->parseInnerTree($elementMap);
         if (!is_array($result)) {
@@ -126,7 +126,7 @@ class Reader extends XMLReader
      *
      * @return array|string|null
      */
-    public function parseInnerTree(array $elementMap = null)
+    public function parseInnerTree(?array $elementMap = null)
     {
         $text = null;
         $elements = [];

--- a/lib/Service.php
+++ b/lib/Service.php
@@ -109,7 +109,7 @@ class Service
      *
      * @return array|object|string
      */
-    public function parse($input, string $contextUri = null, string &$rootElementName = null)
+    public function parse($input, ?string $contextUri = null, ?string &$rootElementName = null)
     {
         if (is_resource($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
@@ -153,7 +153,7 @@ class Service
      *
      * @return array|object|string
      */
-    public function expect($rootElementName, $input, string $contextUri = null)
+    public function expect($rootElementName, $input, ?string $contextUri = null)
     {
         if (is_resource($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
@@ -204,7 +204,7 @@ class Service
      *
      * @return string
      */
-    public function write(string $rootElementName, $value, string $contextUri = null)
+    public function write(string $rootElementName, $value, ?string $contextUri = null)
     {
         $w = $this->getWriter();
         $w->openMemory();
@@ -266,7 +266,7 @@ class Service
      *
      * @throws \InvalidArgumentException
      */
-    public function writeValueObject($object, string $contextUri = null)
+    public function writeValueObject($object, ?string $contextUri = null)
     {
         if (!isset($this->valueObjectMap[get_class($object)])) {
             throw new \InvalidArgumentException('"'.get_class($object).'" is not a registered value object class. Register your class with mapValueObject.');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
   level: 5
+  reportUnmatchedIgnoredErrors: false
   ignoreErrors:
     -
       message: '!Parameter #3 \$namespace of method XMLWriter::startElementNs\(\) expects string, null given.!'


### PR DESCRIPTION
Related issue https://github.com/sabre-io/event/issues/123

- keep running cs-fixer just on the oldest supported PHP 7.1 (it does a little bit different spacing for call-by-reference parameters if I run it in PHP 8)
- run phpstan in both PHP 7.1 and PHP 8.4 to (hopefully) find all the "interesting" things
- adjust nullable parameters to explictly have the `?` to keep PHP 8.4 happy
- - turn off `reportUnmatchedIgnoredErrors` in PHPstan. PHPstan, when run in PHP 7.1, thinks that a call to `startElementNs` has a problem. But, when run with PHP 8.4, it correctly understands that the call is fine. So we don't want to report the unmatched ignored error.
- specify the current minor version of PHP 9 (9.6) just so that it is explicit that 9.6.x should be used
