### PR TITLE
chore: add cs-fixer v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         coverage: ['pcov']
-        code-style: ['no']
+        code-style: ['yes']
         code-analysis: ['no']
         include:
           - php-versions: '7.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
             code-analysis: 'yes'
           - php-versions: '8.4'
             coverage: 'pcov'
-            code-style: 'no'
+            code-style: 'yes'
             code-analysis: 'yes'
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 tests/cov
 tests/.phpunit.result.cache
 .php_cs.cache
+.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,17 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->exclude('vendor')
+    ->in(__DIR__);
+
+$config = new PhpCsFixer\Config();
+$config->setRules([
+    '@PSR1' => true,
+    '@Symfony' => true,
+    'nullable_type_declaration' => [
+        'syntax' => 'question_mark',
+    ],
+    'nullable_type_declaration_for_default_null_value' => true,
+]);
+$config->setFinder($finder);
+return $config;

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.17.1",
+        "friendsofphp/php-cs-fixer": "~2.17.1||3.60",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.6"
     },
@@ -53,7 +53,7 @@
             "phpstan analyse lib tests"
         ],
         "cs-fixer": [
-            "php-cs-fixer fix"
+            "PHP_CS_FIXER_IGNORE_ENV=true php-cs-fixer fix"
         ],
         "phpunit": [
             "phpunit --configuration tests/phpunit.xml"

--- a/lib/Deserializer/functions.php
+++ b/lib/Deserializer/functions.php
@@ -325,8 +325,6 @@ function mixedContent(Reader $reader): array
  *
  * You can use, e.g., a named constructor (factory method) to create an object using
  * this function.
- *
- * @return mixed
  */
 function functionCaller(Reader $reader, callable $func, string $namespace)
 {

--- a/lib/Element/Base.php
+++ b/lib/Element/Base.php
@@ -21,8 +21,6 @@ class Base implements Xml\Element
 {
     /**
      * PHP value to serialize.
-     *
-     * @var mixed
      */
     protected $value;
 
@@ -72,8 +70,6 @@ class Base implements Xml\Element
      *
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @return mixed
      */
     public static function xmlDeserialize(Xml\Reader $reader)
     {

--- a/lib/Element/Elements.php
+++ b/lib/Element/Elements.php
@@ -90,8 +90,6 @@ class Elements implements Xml\Element
      *
      * $reader->parseSubTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @return mixed
      */
     public static function xmlDeserialize(Xml\Reader $reader)
     {

--- a/lib/Element/KeyValue.php
+++ b/lib/Element/KeyValue.php
@@ -90,8 +90,6 @@ class KeyValue implements Xml\Element
      *
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @return mixed
      */
     public static function xmlDeserialize(Xml\Reader $reader)
     {

--- a/lib/Element/Uri.php
+++ b/lib/Element/Uri.php
@@ -84,8 +84,6 @@ class Uri implements Xml\Element
      *
      * $reader->parseSubTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @return mixed
      */
     public static function xmlDeserialize(Xml\Reader $reader)
     {

--- a/lib/Element/XmlFragment.php
+++ b/lib/Element/XmlFragment.php
@@ -135,8 +135,6 @@ XML;
      *
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @return mixed
      */
     public static function xmlDeserialize(Reader $reader)
     {

--- a/lib/LibXMLException.php
+++ b/lib/LibXMLException.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sabre\Xml;
 
 use LibXMLError;
-use Throwable;
 
 /**
  * This exception is thrown when the Reader runs into a parsing error.
@@ -30,10 +29,9 @@ class LibXMLException extends ParseException
      *
      * You should pass a list of LibXMLError objects in its constructor.
      *
-     * @param LibXMLError[] $errors
-     * @param Throwable     $previousException
+     * @param \LibXMLError[] $errors
      */
-    public function __construct(array $errors, int $code = 0, ?Throwable $previousException = null)
+    public function __construct(array $errors, int $code = 0, ?\Throwable $previousException = null)
     {
         $this->errors = $errors;
         parent::__construct($errors[0]->message.' on line '.$errors[0]->line.', column '.$errors[0]->column, $code, $previousException);

--- a/lib/ParseException.php
+++ b/lib/ParseException.php
@@ -13,6 +13,6 @@ use Exception;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class ParseException extends Exception
+class ParseException extends \Exception
 {
 }

--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -19,7 +19,7 @@ use XMLReader;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class Reader extends XMLReader
+class Reader extends \XMLReader
 {
     use ContextStackTrait;
 
@@ -205,7 +205,7 @@ class Reader extends XMLReader
         $previousDepth = $this->depth;
 
         while ($this->read() && $this->depth != $previousDepth) {
-            if (in_array($this->nodeType, [XMLReader::TEXT, XMLReader::CDATA, XMLReader::WHITESPACE])) {
+            if (in_array($this->nodeType, [\XMLReader::TEXT, \XMLReader::CDATA, \XMLReader::WHITESPACE])) {
                 $result .= $this->value;
             }
         }

--- a/lib/Serializer/functions.php
+++ b/lib/Serializer/functions.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\Xml\Serializer;
 
-use InvalidArgumentException;
 use Sabre\Xml\Writer;
 use Sabre\Xml\XmlSerializable;
 
@@ -197,12 +196,12 @@ function standardSerializer(Writer $writer, $value)
                 $writer->write($item);
                 $writer->endElement();
             } else {
-                throw new InvalidArgumentException('The writer does not know how to serialize arrays with keys of type: '.gettype($name));
+                throw new \InvalidArgumentException('The writer does not know how to serialize arrays with keys of type: '.gettype($name));
             }
         }
     } elseif (is_object($value)) {
-        throw new InvalidArgumentException('The writer cannot serialize objects of class: '.get_class($value));
+        throw new \InvalidArgumentException('The writer cannot serialize objects of class: '.get_class($value));
     } elseif (!is_null($value)) {
-        throw new InvalidArgumentException('The writer cannot serialize values of type: '.gettype($value));
+        throw new \InvalidArgumentException('The writer cannot serialize values of type: '.gettype($value));
     }
 }

--- a/lib/Service.php
+++ b/lib/Service.php
@@ -105,9 +105,9 @@ class Service
      *
      * @param string|resource $input
      *
-     * @throws ParseException
-     *
      * @return array|object|string
+     *
+     * @throws ParseException
      */
     public function parse($input, ?string $contextUri = null, ?string &$rootElementName = null)
     {
@@ -149,9 +149,9 @@ class Service
      * @param string|string[] $rootElementName
      * @param string|resource $input
      *
-     * @throws ParseException
-     *
      * @return array|object|string
+     *
+     * @throws ParseException
      */
     public function expect($rootElementName, $input, ?string $contextUri = null)
     {

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    const VERSION = '2.2.9';
+    public const VERSION = '2.2.9';
 }

--- a/lib/Writer.php
+++ b/lib/Writer.php
@@ -30,7 +30,7 @@ use XMLWriter;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class Writer extends XMLWriter
+class Writer extends \XMLWriter
 {
     use ContextStackTrait;
 
@@ -93,8 +93,6 @@ class Writer extends XMLWriter
      *      ]
      *    ]
      * ]
-     *
-     * @param mixed $value
      */
     public function write($value)
     {
@@ -151,7 +149,7 @@ class Writer extends XMLWriter
 
         if (!$this->namespacesWritten) {
             foreach ($this->namespaceMap as $namespace => $prefix) {
-                $this->writeAttribute(($prefix ? 'xmlns:'.$prefix : 'xmlns'), $namespace);
+                $this->writeAttribute($prefix ? 'xmlns:'.$prefix : 'xmlns', $namespace);
             }
             $this->namespacesWritten = true;
         }

--- a/lib/XmlDeserializable.php
+++ b/lib/XmlDeserializable.php
@@ -31,8 +31,6 @@ interface XmlDeserializable
      *
      * $reader->parseInnerTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @return mixed
      */
     public static function xmlDeserialize(Reader $reader);
 }

--- a/tests/Sabre/Xml/Element/Eater.php
+++ b/tests/Sabre/Xml/Element/Eater.php
@@ -52,8 +52,6 @@ class Eater implements Xml\Element
      *
      * $reader->parseSubTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @return mixed
      */
     public static function xmlDeserialize(Xml\Reader $reader)
     {

--- a/tests/Sabre/Xml/Element/Mock.php
+++ b/tests/Sabre/Xml/Element/Mock.php
@@ -44,8 +44,6 @@ class Mock implements Xml\Element
      *
      * $reader->parseSubTree() will parse the entire sub-tree, and advance to
      * the next element.
-     *
-     * @return mixed
      */
     public static function xmlDeserialize(Xml\Reader $reader)
     {

--- a/tests/Sabre/Xml/Element/XmlFragmentTest.php
+++ b/tests/Sabre/Xml/Element/XmlFragmentTest.php
@@ -120,7 +120,7 @@ BLA;
         ];
         $writer->openMemory();
         $writer->startDocument('1.0');
-        //$writer->setIndent(true);
+        // $writer->setIndent(true);
         $writer->write([
             '{http://sabredav.org/ns}root' => [
                 '{http://sabredav.org/ns}fragment' => new XmlFragment($input),

--- a/tests/Sabre/Xml/ReaderTest.php
+++ b/tests/Sabre/Xml/ReaderTest.php
@@ -195,7 +195,7 @@ BLA;
 
         $reader = new Reader();
         $reader->elementMap = [
-            '{http://sabredav.org/ns}elem1' => new \StdClass(),
+            '{http://sabredav.org/ns}elem1' => new \stdClass(),
         ];
         $reader->xml($input);
 

--- a/tests/Sabre/Xml/ServiceTest.php
+++ b/tests/Sabre/Xml/ServiceTest.php
@@ -278,7 +278,7 @@ XML;
 XML;
 
         $ns = 'http://sabredav.org/ns';
-        $orderService = new \Sabre\Xml\Service();
+        $orderService = new Service();
         $orderService->mapValueObject('{'.$ns.'}order', 'Sabre\Xml\Order');
         $orderService->mapValueObject('{'.$ns.'}status', 'Sabre\Xml\OrderStatus');
         $orderService->namespaceMap[$ns] = null;
@@ -317,7 +317,7 @@ XML;
 XML;
 
         $ns = 'http://sabredav.org/ns';
-        $orderService = new \Sabre\Xml\Service();
+        $orderService = new Service();
         $orderService->mapValueObject('{'.$ns.'}order', 'Sabre\Xml\Order');
         $orderService->mapValueObject('{'.$ns.'}status', 'Sabre\Xml\OrderStatus');
         $orderService->namespaceMap[$ns] = null;
@@ -342,7 +342,7 @@ XML;
     {
         $this->expectException(\InvalidArgumentException::class);
         $service = new Service();
-        $service->writeValueObject(new \StdClass());
+        $service->writeValueObject(new \stdClass());
     }
 
     public function testParseClarkNotation()

--- a/tests/Sabre/Xml/WriterTest.php
+++ b/tests/Sabre/Xml/WriterTest.php
@@ -340,7 +340,7 @@ HI;
     public function testWriteBadObject()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->writer->write(new \StdClass());
+        $this->writer->write(new \stdClass());
     }
 
     public function testStartElementSimple()


### PR DESCRIPTION
Add the ability to use php-cs-fixer major version 3.
Add `.php-cs-fixer.dist.php` (the settings of php-cs-fixer for major version 3) and put the `nullable_type_declaration` check into it.
Run cs-fixer on PHP 8.4.
Leave the old cs-fixer still running on PHP 7.1.
And run cs-fixer on every PHP version, to be sure. In CI, `composer` will choose whether to use major version 2 or 3 of php-cs-fixer.

The newer cs-fixer v3 makes various nice fixes that do not break on PHP 7.1.
The old cs-fixer v2 is happy with the changes, it does not try to change them back - that is nice.

This is only needed for this old release series that still has PHP 7.1 support. We can run both cs-fixer and phpstan (and phpunit) on PHP 7.1 through 8.4. I think that helps give confidence that the code works across that range of PHP versions.

Note: when I forward-port all this stuff to later major releases, I won't need to do all this tweaking because we move to supporting only PHP 7.4 and up.