### PR TITLE
Add PHP 8.4 compliance for v3 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,16 @@ jobs:
       matrix:
         php-versions: ['8.0', '8.1', '8.2', '8.3']
         coverage: ['pcov']
+        code-style: ['no']
         code-analysis: ['no']
         include:
           - php-versions: '7.4'
             coverage: 'none'
+            code-style: 'yes'
+            code-analysis: 'yes'
+          - php-versions: '8.4'
+            coverage: 'pcov'
+            code-style: 'no'
             code-analysis: 'yes'
     steps:
       - name: Checkout
@@ -48,8 +54,8 @@ jobs:
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Code Analysis (PHP CS-Fixer)
-        if: matrix.code-analysis == 'yes'
-        run: php vendor/bin/php-cs-fixer fix --dry-run --diff
+        if: matrix.code-style == 'yes'
+        run: PHP_CS_FIXER_IGNORE_ENV=true php vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Code Analysis (PHPStan)
         if: matrix.code-analysis == 'yes'

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,6 +11,10 @@ $config = new PhpCsFixer\Config();
 $config->setRules([
     '@PSR1' => true,
     '@Symfony' => true,
+    'nullable_type_declaration' => [
+        'syntax' => 'question_mark',
+    ],
+    'nullable_type_declaration_for_default_null_value' => true,
 ]);
 $config->setFinder($finder);
 

--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,8 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.38",
-        "phpstan/phpstan": "^1.10",
+        "friendsofphp/php-cs-fixer": "^3.64",
+        "phpstan/phpstan": "^1.12",
         "phpunit/phpunit" : "^9.6"
     },
     "scripts": {
@@ -56,7 +56,7 @@
             "phpstan analyse --generate-baseline phpstan-baseline.neon"
         ],
         "cs-fixer": [
-            "php-cs-fixer fix"
+            "PHP_CS_FIXER_IGNORE_ENV=true php-cs-fixer fix"
         ],
         "phpunit": [
             "phpunit --configuration tests/phpunit.xml"

--- a/lib/ContextStackTrait.php
+++ b/lib/ContextStackTrait.php
@@ -110,7 +110,7 @@ trait ContextStackTrait
             $this->elementMap,
             $this->contextUri,
             $this->namespaceMap,
-            $this->classMap
+            $this->classMap,
         ) = array_pop($this->contextStack);
     }
 }

--- a/lib/Writer.php
+++ b/lib/Writer.php
@@ -235,7 +235,7 @@ class Writer extends \XMLWriter
 
         list(
             $namespace,
-            $localName
+            $localName,
         ) = Service::parseClarkNotation($name);
 
         if (array_key_exists($namespace, $this->namespaceMap)) {


### PR DESCRIPTION
I have taken the various CI and tooling changes from 2.2 and applied them here to the v3 branch.

There is not much code change needed - most of the real changes needed for 8.4 are already in the v3 branch. But this gets CI running on PHP 8.4 to confirm that.