### PR TITLE
Add PHP 8.4 compliance for v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,16 @@ jobs:
       matrix:
         php-versions: ['8.0', '8.1', '8.2', '8.3']
         coverage: ['pcov']
+        code-style: ['no']
         code-analysis: ['no']
         include:
           - php-versions: '7.4'
             coverage: 'none'
+            code-style: 'yes'
+            code-analysis: 'yes'
+          - php-versions: '8.4'
+            coverage: 'pcov'
+            code-style: 'no'
             code-analysis: 'yes'
     steps:
       - name: Checkout
@@ -48,8 +54,8 @@ jobs:
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Code Analysis (PHP CS-Fixer)
-        if: matrix.code-analysis == 'yes'
-        run: php vendor/bin/php-cs-fixer fix --dry-run --diff
+        if: matrix.code-style == 'yes'
+        run: PHP_CS_FIXER_IGNORE_ENV=true php vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Code Analysis (PHPStan)
         if: matrix.code-analysis == 'yes'

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,6 +11,10 @@ $config = new PhpCsFixer\Config();
 $config->setRules([
     '@PSR1' => true,
     '@Symfony' => true,
+    'nullable_type_declaration' => [
+        'syntax' => 'question_mark',
+    ],
+    'nullable_type_declaration_for_default_null_value' => true,
 ]);
 $config->setFinder($finder);
 

--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,8 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.56",
-        "phpstan/phpstan": "^1.11",
+        "friendsofphp/php-cs-fixer": "^3.64",
+        "phpstan/phpstan": "^1.12",
         "phpunit/phpunit" : "^9.6"
     },
     "scripts": {
@@ -56,7 +56,7 @@
             "phpstan analyse --generate-baseline phpstan-baseline.neon"
         ],
         "cs-fixer": [
-            "php-cs-fixer fix"
+            "PHP_CS_FIXER_IGNORE_ENV=true php-cs-fixer fix"
         ],
         "phpunit": [
             "phpunit --configuration tests/phpunit.xml"

--- a/lib/ContextStackTrait.php
+++ b/lib/ContextStackTrait.php
@@ -110,7 +110,7 @@ trait ContextStackTrait
             $this->elementMap,
             $this->contextUri,
             $this->namespaceMap,
-            $this->classMap
+            $this->classMap,
         ) = array_pop($this->contextStack);
     }
 }

--- a/lib/Service.php
+++ b/lib/Service.php
@@ -109,7 +109,7 @@ class Service
      */
     public function parse($input, ?string $contextUri = null, ?string &$rootElementName = null)
     {
-        if (is_resource($input)) {
+        if (!is_string($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
             $input = (string) stream_get_contents($input);
@@ -153,7 +153,7 @@ class Service
      */
     public function expect($rootElementName, $input, ?string $contextUri = null)
     {
-        if (is_resource($input)) {
+        if (!is_string($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
             $input = (string) stream_get_contents($input);

--- a/lib/Service.php
+++ b/lib/Service.php
@@ -112,7 +112,14 @@ class Service
         if (!is_string($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
-            $input = (string) stream_get_contents($input);
+            if (is_resource($input)) {
+                $input = (string) stream_get_contents($input);
+            } else {
+                // Input is not a string and not a resource.
+                // Therefore, it has to be a closed resource.
+                // Effectively empty input has been passed in.
+                $input = '';
+            }
         }
 
         // If input is empty, then it's safe to throw an exception
@@ -156,7 +163,14 @@ class Service
         if (!is_string($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
-            $input = (string) stream_get_contents($input);
+            if (is_resource($input)) {
+                $input = (string) stream_get_contents($input);
+            } else {
+                // Input is not a string and not a resource.
+                // Therefore, it has to be a closed resource.
+                // Effectively empty input has been passed in.
+                $input = '';
+            }
         }
 
         // If input is empty, then it's safe to throw an exception

--- a/lib/Writer.php
+++ b/lib/Writer.php
@@ -235,7 +235,7 @@ class Writer extends \XMLWriter
 
         list(
             $namespace,
-            $localName
+            $localName,
         ) = Service::parseClarkNotation($name);
 
         if (array_key_exists($namespace, $this->namespaceMap)) {

--- a/tests/Sabre/Xml/ServiceTest.php
+++ b/tests/Sabre/Xml/ServiceTest.php
@@ -388,6 +388,19 @@ XML;
         $data[] = [$emptyResource];
         $data[] = [''];
 
+        // Also test trying to parse a resource stream that has already been closed.
+        $xml = <<<XML
+<root xmlns="http://sabre.io/ns">
+  <child>value</child>
+</root>
+XML;
+        $stream = fopen('php://memory', 'r+');
+        self:assertIsResource($stream);
+        fwrite($stream, $xml);
+        rewind($stream);
+        fclose($stream);
+        $data[] = [$stream];
+
         return $data;
     }
 


### PR DESCRIPTION
Apply the small code changes and the CI and tooling changes for PHP 8.4 to master (which is where the v4 release series comes from).

And fixup `parse()` and `expect()` functions in `Service.php` - see the comments below about what `phpstan` noticed.
Now, if someone passes a closed resource, we will throw the usual `ParseException` that is thrown when someone passes an empty input.