### PR TITLE
Backport fix for "Passing a closed resource to Service parse or expect" to 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.17.1||^3.63",
+        "friendsofphp/php-cs-fixer": "~2.17.1||3.63.2",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.6"
     },

--- a/lib/Service.php
+++ b/lib/Service.php
@@ -111,7 +111,7 @@ class Service
      */
     public function parse($input, ?string $contextUri = null, ?string &$rootElementName = null)
     {
-        if (is_resource($input)) {
+        if (!is_string($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
             $input = (string) stream_get_contents($input);
@@ -155,7 +155,7 @@ class Service
      */
     public function expect($rootElementName, $input, ?string $contextUri = null)
     {
-        if (is_resource($input)) {
+        if (!is_string($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
             $input = (string) stream_get_contents($input);

--- a/lib/Service.php
+++ b/lib/Service.php
@@ -114,7 +114,14 @@ class Service
         if (!is_string($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
-            $input = (string) stream_get_contents($input);
+            if (is_resource($input)) {
+                $input = (string) stream_get_contents($input);
+            } else {
+                // Input is not a string and not a resource.
+                // Therefore, it has to be a closed resource.
+                // Effectively empty input has been passed in.
+                $input = '';
+            }
         }
 
         // If input is empty, then it's safe to throw an exception
@@ -158,7 +165,14 @@ class Service
         if (!is_string($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
-            $input = (string) stream_get_contents($input);
+            if (is_resource($input)) {
+                $input = (string) stream_get_contents($input);
+            } else {
+                // Input is not a string and not a resource.
+                // Therefore, it has to be a closed resource.
+                // Effectively empty input has been passed in.
+                $input = '';
+            }
         }
 
         // If input is empty, then it's safe to throw an exception

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,6 @@ parameters:
     -
       message: '!Parameter #3 \$namespace of method XMLWriter::startElementNs\(\) expects string, null given.!'
       path: lib/Writer.php
+    -
+      message: '!Else branch is unreachable because previous condition is always true.!'
+      path: lib/Service.php

--- a/tests/Sabre/Xml/ServiceTest.php
+++ b/tests/Sabre/Xml/ServiceTest.php
@@ -372,7 +372,6 @@ XML;
 </root>
 XML;
         $stream = fopen('php://memory', 'r+');
-        self:assertIsResource($stream);
         fwrite($stream, $xml);
         rewind($stream);
         fclose($stream);

--- a/tests/Sabre/Xml/ServiceTest.php
+++ b/tests/Sabre/Xml/ServiceTest.php
@@ -365,6 +365,19 @@ XML;
         $data[] = [$emptyResource];
         $data[] = [''];
 
+        // Also test trying to parse a resource stream that has already been closed.
+        $xml = <<<XML
+<root xmlns="http://sabre.io/ns">
+  <child>value</child>
+</root>
+XML;
+        $stream = fopen('php://memory', 'r+');
+        self:assertIsResource($stream);
+        fwrite($stream, $xml);
+        rewind($stream);
+        fclose($stream);
+        $data[] = [$stream];
+
         return $data;
     }
 


### PR DESCRIPTION
Backport the code related to issue #297 from PR #296 to the 2.2 branch.

~And apply code-style changes that the latest php-cs-fixer 3.64 makes.~

php-cs-fixer 3.64 wants to apply trailing-comma to `list(a,b,c,)` as part of the latest `Symfony` code style.
The old php-cs-fixer v2 does not know about that.
So for this 2.2 branch we can lock the new php-cs-fixer to 3.63.2 so that it does not do any code-style changes.
That lets the CI pass.

In future we will probably drop the support for PHP 7.1 7.2 7.3 and therefore can stop using php-cs-fixer v2. I will do that for a 2.3 series "some day".