### PR TITLE
Backport fix for "Passing a closed resource to Service parse or expect" to v3

### DIFF
--- a/lib/Service.php
+++ b/lib/Service.php
@@ -109,7 +109,7 @@ class Service
      */
     public function parse($input, ?string $contextUri = null, ?string &$rootElementName = null)
     {
-        if (is_resource($input)) {
+        if (!is_string($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
             $input = (string) stream_get_contents($input);
@@ -153,7 +153,7 @@ class Service
      */
     public function expect($rootElementName, $input, ?string $contextUri = null)
     {
-        if (is_resource($input)) {
+        if (!is_string($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
             $input = (string) stream_get_contents($input);

--- a/lib/Service.php
+++ b/lib/Service.php
@@ -112,7 +112,14 @@ class Service
         if (!is_string($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
-            $input = (string) stream_get_contents($input);
+            if (is_resource($input)) {
+                $input = (string) stream_get_contents($input);
+            } else {
+                // Input is not a string and not a resource.
+                // Therefore, it has to be a closed resource.
+                // Effectively empty input has been passed in.
+                $input = '';
+            }
         }
 
         // If input is empty, then it's safe to throw an exception
@@ -156,7 +163,14 @@ class Service
         if (!is_string($input)) {
             // Unfortunately the XMLReader doesn't support streams. When it
             // does, we can optimize this.
-            $input = (string) stream_get_contents($input);
+            if (is_resource($input)) {
+                $input = (string) stream_get_contents($input);
+            } else {
+                // Input is not a string and not a resource.
+                // Therefore, it has to be a closed resource.
+                // Effectively empty input has been passed in.
+                $input = '';
+            }
         }
 
         // If input is empty, then it's safe to throw an exception

--- a/tests/Sabre/Xml/ServiceTest.php
+++ b/tests/Sabre/Xml/ServiceTest.php
@@ -382,6 +382,19 @@ XML;
         $data[] = [$emptyResource];
         $data[] = [''];
 
+        // Also test trying to parse a resource stream that has already been closed.
+        $xml = <<<XML
+<root xmlns="http://sabre.io/ns">
+  <child>value</child>
+</root>
+XML;
+        $stream = fopen('php://memory', 'r+');
+        self:assertIsResource($stream);
+        fwrite($stream, $xml);
+        rewind($stream);
+        fclose($stream);
+        $data[] = [$stream];
+
         return $data;
     }
 

--- a/tests/Sabre/Xml/ServiceTest.php
+++ b/tests/Sabre/Xml/ServiceTest.php
@@ -389,7 +389,6 @@ XML;
 </root>
 XML;
         $stream = fopen('php://memory', 'r+');
-        self:assertIsResource($stream);
         fwrite($stream, $xml);
         rewind($stream);
         fclose($stream);


### PR DESCRIPTION
Backport the code related to issue #297 from PR #296 to the v3 branch.