### PR TITLE
chore: drop PHP less than 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3','8.4']
+        php-versions: ['8.3','8.4']
         coverage: ['pcov']
         code-style: ['no']
         code-analysis: ['no']
         rector-check: ['no']
         include:
-          - php-versions: '7.4'
-            coverage: 'none'
+          - php-versions: '8.2'
+            coverage: 'pcov'
             code-style: 'yes'
             code-analysis: 'yes'
             rector-check: 'no'

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage" : "https://sabre.io/xml/",
     "license" : "BSD-3-Clause",
     "require" : {
-        "php" : "^7.4 || ^8.0",
+        "php" : "^8.2",
         "ext-xmlwriter" : "*",
         "ext-xmlreader" : "*",
         "ext-dom" : "*",
@@ -44,10 +44,13 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.94",
+        "friendsofphp/php-cs-fixer": "^3.95",
         "phpstan/phpstan": "^2.1",
-        "phpunit/phpunit": "^9.6",
-        "rector/rector": "^2.3"
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "phpstan/extension-installer": "^1.4",
+        "phpunit/phpunit": "^10.5",
+        "rector/rector": "^2.4"
     },
     "scripts": {
         "phpstan": [
@@ -73,5 +76,13 @@
             "composer cs-fixer",
             "composer phpunit"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        },
+        "platform": {
+            "php": "8.2"
+        }
     }
 }

--- a/lib/Deserializer/functions.php
+++ b/lib/Deserializer/functions.php
@@ -212,11 +212,13 @@ function valueObject(Reader $reader, string $className, string $namespace): obje
 
     $reader->read();
     do {
-        if (Reader::ELEMENT === $reader->nodeType && $reader->namespaceURI == $namespace) {
+        if (Reader::ELEMENT === $reader->nodeType && $reader->namespaceURI === $namespace) {
             if (property_exists($valueObject, $reader->localName)) {
                 if (is_array($defaultProperties[$reader->localName])) {
+                    // @phpstan-ignore property.dynamicName
                     $valueObject->{$reader->localName}[] = $reader->parseCurrentElement()['value'];
                 } else {
+                    // @phpstan-ignore property.dynamicName
                     $valueObject->{$reader->localName} = $reader->parseCurrentElement()['value'];
                 }
             } else {
@@ -315,12 +317,12 @@ function mixedContent(Reader $reader): array
     $content = [];
     $reader->read();
     while (true) {
-        if (Reader::ELEMENT == $reader->nodeType) {
+        if (Reader::ELEMENT === $reader->nodeType) {
             $content[] = $reader->parseCurrentElement();
-        } elseif ($reader->depth >= $previousDepth && in_array($reader->nodeType, [Reader::TEXT, Reader::CDATA, Reader::WHITESPACE])) {
+        } elseif ($reader->depth >= $previousDepth && in_array($reader->nodeType, [Reader::TEXT, Reader::CDATA, Reader::WHITESPACE], true)) {
             $content[] = $reader->value;
             $reader->read();
-        } elseif (Reader::END_ELEMENT == $reader->nodeType) {
+        } elseif (Reader::END_ELEMENT === $reader->nodeType) {
             // Ensuring we are moving the cursor after the end element.
             $reader->read();
             break;
@@ -353,7 +355,7 @@ function functionCaller(Reader $reader, callable $func, string $namespace)
     $funcArgs = [];
     if (is_array($func)) {
         $ref = new \ReflectionMethod($func[0], $func[1]);
-    } elseif (is_string($func) && false !== strpos($func, '::')) {
+    } elseif (is_string($func) && str_contains($func, '::')) {
         // We have a string that should refer to a method that exists, like "MyClass::someMethod"
         // ReflectionMethod knows how to handle that as-is
         $ref = new \ReflectionMethod($func);
@@ -371,7 +373,7 @@ function functionCaller(Reader $reader, callable $func, string $namespace)
 
     $reader->read();
     do {
-        if (Reader::ELEMENT === $reader->nodeType && $reader->namespaceURI == $namespace) {
+        if (Reader::ELEMENT === $reader->nodeType && $reader->namespaceURI === $namespace) {
             if (array_key_exists($reader->localName, $funcArgs)) {
                 $funcArgs[$reader->localName] = $reader->parseCurrentElement()['value'];
             } else {

--- a/lib/Element/Base.php
+++ b/lib/Element/Base.php
@@ -20,18 +20,12 @@ use Sabre\Xml;
 class Base implements Xml\Element
 {
     /**
-     * @var mixed PHP value to serialize
-     */
-    protected $value;
-
-    /**
      * Constructor.
      *
      * @param mixed $value PHP value to serialize
      */
-    public function __construct($value = null)
+    public function __construct(protected $value = null)
     {
-        $this->value = $value;
     }
 
     /**

--- a/lib/Element/Cdata.php
+++ b/lib/Element/Cdata.php
@@ -22,16 +22,14 @@ use Sabre\Xml;
 class Cdata implements Xml\XmlSerializable
 {
     /**
-     * CDATA element value.
-     */
-    protected string $value;
-
-    /**
      * Constructor.
      */
-    public function __construct(string $value)
-    {
-        $this->value = $value;
+    public function __construct(
+        /**
+         * CDATA element value.
+         */
+        protected string $value,
+    ) {
     }
 
     /**
@@ -52,6 +50,6 @@ class Cdata implements Xml\XmlSerializable
      */
     public function xmlSerialize(Xml\Writer $writer): void
     {
-        $writer->writeCData($this->value);
+        $writer->writeCdata($this->value);
     }
 }

--- a/lib/Element/Elements.php
+++ b/lib/Element/Elements.php
@@ -38,20 +38,16 @@ use Sabre\Xml\Serializer;
 class Elements implements Xml\Element
 {
     /**
-     * Value to serialize.
-     *
-     * @var array<int, mixed>
-     */
-    protected array $value;
-
-    /**
      * Constructor.
      *
      * @param array<int, mixed> $value
      */
-    public function __construct(array $value = [])
-    {
-        $this->value = $value;
+    public function __construct(
+        /**
+         * Value to serialize.
+         */
+        protected array $value = [],
+    ) {
     }
 
     /**

--- a/lib/Element/KeyValue.php
+++ b/lib/Element/KeyValue.php
@@ -38,20 +38,16 @@ use Sabre\Xml\Deserializer;
 class KeyValue implements Xml\Element
 {
     /**
-     * Value to serialize.
-     *
-     * @var array<string, mixed>
-     */
-    protected array $value;
-
-    /**
      * Constructor.
      *
      * @param array<string, mixed> $value
      */
-    public function __construct(array $value = [])
-    {
-        $this->value = $value;
+    public function __construct(
+        /**
+         * Value to serialize.
+         */
+        protected array $value = [],
+    ) {
     }
 
     /**

--- a/lib/Element/Uri.php
+++ b/lib/Element/Uri.php
@@ -27,16 +27,14 @@ use function Sabre\Uri\resolve;
 class Uri implements Xml\Element
 {
     /**
-     * Uri element value.
-     */
-    protected string $value;
-
-    /**
      * Constructor.
      */
-    public function __construct(string $value)
-    {
-        $this->value = $value;
+    public function __construct(
+        /**
+         * Uri element value.
+         */
+        protected string $value,
+    ) {
     }
 
     /**

--- a/lib/Element/XmlFragment.php
+++ b/lib/Element/XmlFragment.php
@@ -25,16 +25,14 @@ use Sabre\Xml\Writer;
 class XmlFragment implements Element
 {
     /**
-     * The inner XML value.
-     */
-    protected string $xml;
-
-    /**
      * Constructor.
      */
-    public function __construct(string $xml)
-    {
-        $this->xml = $xml;
+    public function __construct(
+        /**
+         * The inner XML value.
+         */
+        protected string $xml,
+    ) {
     }
 
     /**
@@ -63,8 +61,6 @@ class XmlFragment implements Element
      */
     public function xmlSerialize(Writer $writer): void
     {
-        $reader = new Reader();
-
         // Wrapping the xml in a container, so root-less values can still be
         // parsed.
         $xml = <<<XML
@@ -72,7 +68,10 @@ class XmlFragment implements Element
 <xml-fragment xmlns="http://sabre.io/ns">{$this->getXml()}</xml-fragment>
 XML;
 
-        $reader->xml($xml);
+        $reader = Reader::XML($xml);
+        if (!$reader instanceof Reader) {
+            throw new \InvalidArgumentException('Invalid XML string');
+        }
 
         while ($reader->read()) {
             if ($reader->depth < 1) {

--- a/lib/LibXMLException.php
+++ b/lib/LibXMLException.php
@@ -18,23 +18,18 @@ use LibXMLError;
 class LibXMLException extends ParseException
 {
     /**
-     * The error list.
-     *
-     * @var \LibXMLError[]
-     */
-    protected array $errors;
-
-    /**
      * Creates the exception.
      *
      * You should pass a list of LibXMLError objects in its constructor.
      *
      * @param \LibXMLError[] $errors
      */
-    public function __construct(array $errors, int $code = 0, ?\Throwable $previousException = null)
+    public function __construct(/**
+     * The error list.
+     */
+        protected array $errors, int $code = 0, ?\Throwable $previousException = null)
     {
-        $this->errors = $errors;
-        parent::__construct($errors[0]->message.' on line '.$errors[0]->line.', column '.$errors[0]->column, $code, $previousException);
+        parent::__construct($this->errors[0]->message.' on line '.$this->errors[0]->line.', column '.$this->errors[0]->column, $code, $previousException);
     }
 
     /**

--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -23,6 +23,21 @@ class Reader extends \XMLReader
 {
     use ContextStackTrait;
 
+    public static function XML(string $source, ?string $encoding = null, int $flags = 0): false|Reader
+    {
+        $xmlReader = parent::XML($source, $encoding, $flags);
+        $reader = new Reader();
+        if ($xmlReader instanceof \XMLReader) {
+            foreach (get_object_vars($xmlReader) as $key => $value) {
+                $reader->{$key} = $value; // @phpstan-ignore property.dynamicName
+            }
+
+            return $reader;
+        }
+
+        return false;
+    }
+
     /**
      * Returns the current nodename in clark-notation.
      *
@@ -33,7 +48,7 @@ class Reader extends \XMLReader
      */
     public function getClark(): ?string
     {
-        if (!$this->localName) {
+        if ('' === $this->localName) {
             return null;
         }
 
@@ -67,7 +82,7 @@ class Reader extends \XMLReader
                 if (!$this->read()) {
                     $errors = libxml_get_errors();
                     libxml_clear_errors();
-                    if ($errors) {
+                    if (count($errors) > 0) {
                         throw new LibXMLException($errors);
                     }
                 }
@@ -77,7 +92,7 @@ class Reader extends \XMLReader
             // last line of defense in case errors did occur above
             $errors = libxml_get_errors();
             libxml_clear_errors();
-            if ($errors) {
+            if (count($errors) > 0) {
                 throw new LibXMLException($errors);
             }
         } finally {
@@ -153,7 +168,7 @@ class Reader extends \XMLReader
             if (!$this->read()) {
                 $errors = libxml_get_errors();
                 libxml_clear_errors();
-                if ($errors) {
+                if (count($errors) > 0) {
                     throw new LibXMLException($errors);
                 }
                 throw new ParseException('This should never happen (famous last words)');
@@ -165,7 +180,7 @@ class Reader extends \XMLReader
                 if (!$this->isValid()) {
                     $errors = libxml_get_errors();
 
-                    if ($errors) {
+                    if (count($errors) > 0) {
                         libxml_clear_errors();
                         throw new LibXMLException($errors);
                     }
@@ -199,7 +214,7 @@ class Reader extends \XMLReader
             }
         }
 
-        return $elements ?: $text;
+        return count($elements) > 0 ? $elements : $text;
     }
 
     /**
@@ -210,8 +225,8 @@ class Reader extends \XMLReader
         $result = '';
         $previousDepth = $this->depth;
 
-        while ($this->read() && $this->depth != $previousDepth) {
-            if (in_array($this->nodeType, [\XMLReader::TEXT, \XMLReader::CDATA, \XMLReader::WHITESPACE])) {
+        while ($this->read() && $this->depth !== $previousDepth) {
+            if (in_array($this->nodeType, [\XMLReader::TEXT, \XMLReader::CDATA, \XMLReader::WHITESPACE], true)) {
                 $result .= $this->value;
             }
         }
@@ -222,12 +237,12 @@ class Reader extends \XMLReader
     /**
      * Parses the current XML element.
      *
-     * This method returns arn array with 3 properties:
+     * This method returns an array with 3 properties:
      *   * name - A clark-notation XML element name.
      *   * value - The parsed value.
      *   * attributes - A key-value list of attributes.
      *
-     * @return array <string, mixed>
+     * @return array{'name': string|null, 'value': mixed, 'attributes': array<string, mixed>}
      */
     public function parseCurrentElement(): array
     {
@@ -266,7 +281,7 @@ class Reader extends \XMLReader
         $attributes = [];
 
         while ($this->moveToNextAttribute()) {
-            if ($this->namespaceURI) {
+            if ('' !== $this->namespaceURI) {
                 // Ignoring 'xmlns', it doesn't make any sense.
                 if ('http://www.w3.org/2000/xmlns/' === $this->namespaceURI) {
                     continue;
@@ -290,10 +305,10 @@ class Reader extends \XMLReader
     public function getDeserializerForElementName(string $name): callable
     {
         if (!array_key_exists($name, $this->elementMap)) {
-            if ('{}' == substr($name, 0, 2) && array_key_exists(substr($name, 2), $this->elementMap)) {
+            if (str_starts_with($name, '{}') && array_key_exists(substr($name, 2), $this->elementMap)) {
                 $name = substr($name, 2);
             } else {
-                return [Element\Base::class, 'xmlDeserialize'];
+                return Element\Base::xmlDeserialize(...);
             }
         }
 
@@ -303,14 +318,14 @@ class Reader extends \XMLReader
         }
 
         if (is_subclass_of($deserializer, XmlDeserializable::class)) {
-            return [$deserializer, 'xmlDeserialize'];
+            return fn (Reader $reader) => $deserializer::xmlDeserialize($reader);
         }
 
         $type = gettype($deserializer);
         if (is_string($deserializer)) {
             $type .= ' ('.$deserializer.')';
         } elseif (is_object($deserializer)) {
-            $type .= ' ('.get_class($deserializer).')';
+            $type .= ' ('.$deserializer::class.')';
         }
         throw new \LogicException('Could not use this type as a deserializer: '.$type.' for element: '.$name);
     }

--- a/lib/Serializer/functions.php
+++ b/lib/Serializer/functions.php
@@ -157,9 +157,9 @@ function standardSerializer(Writer $writer, $value): void
     } elseif ($value instanceof XmlSerializable) {
         // XmlSerializable classes or Element classes.
         $value->xmlSerialize($writer);
-    } elseif (is_object($value) && isset($writer->classMap[get_class($value)])) {
+    } elseif (is_object($value) && isset($writer->classMap[$value::class])) {
         // It's an object which class appears in the classmap.
-        $writer->classMap[get_class($value)]($writer, $value);
+        $writer->classMap[$value::class]($writer, $value);
     } elseif (is_callable($value)) {
         // A callback
         $value($writer);
@@ -200,7 +200,7 @@ function standardSerializer(Writer $writer, $value): void
             }
         }
     } elseif (is_object($value)) {
-        throw new \InvalidArgumentException('The writer cannot serialize objects of class: '.get_class($value));
+        throw new \InvalidArgumentException('The writer cannot serialize objects of class: '.$value::class);
     } elseif (!is_null($value)) {
         throw new \InvalidArgumentException('The writer cannot serialize values of type: '.gettype($value));
     }

--- a/lib/Service.php
+++ b/lib/Service.php
@@ -123,13 +123,15 @@ class Service
         }
 
         // If input is empty, then it's safe to throw an exception
-        if (empty($input)) {
+        if ('' === $input) {
             throw new ParseException('The input element to parse is empty. Do not attempt to parse');
         }
 
-        $r = $this->getReader();
+        $r = Reader::XML($input, null, $this->options);
+        if (!$r instanceof Reader) {
+            throw new ParseException('The input element to parse is invalid. Do not attempt to parse');
+        }
         $r->contextUri = $contextUri;
-        $r->XML($input, null, $this->options);
 
         $result = $r->parse();
         $rootElementName = $result['name'];
@@ -174,13 +176,15 @@ class Service
         }
 
         // If input is empty, then it's safe to throw an exception
-        if (empty($input)) {
+        if ('' === $input) {
             throw new ParseException('The input element to parse is empty. Do not attempt to parse');
         }
 
-        $r = $this->getReader();
+        $r = Reader::XML($input, null, $this->options);
+        if (!$r instanceof Reader) {
+            throw new ParseException('The input element to parse is invalid. Do not attempt to parse');
+        }
         $r->contextUri = $contextUri;
-        $r->XML($input, null, $this->options);
 
         $rootElementName = (array) $rootElementName;
 
@@ -276,12 +280,12 @@ class Service
      */
     public function writeValueObject(object $object, ?string $contextUri = null): string
     {
-        if (!isset($this->valueObjectMap[get_class($object)])) {
-            throw new \InvalidArgumentException('"'.get_class($object).'" is not a registered value object class. Register your class with mapValueObject.');
+        if (!isset($this->valueObjectMap[$object::class])) {
+            throw new \InvalidArgumentException('"'.$object::class.'" is not a registered value object class. Register your class with mapValueObject.');
         }
 
         return $this->write(
-            $this->valueObjectMap[get_class($object)],
+            $this->valueObjectMap[$object::class],
             $object,
             $contextUri
         );
@@ -302,7 +306,7 @@ class Service
         static $cache = [];
 
         if (!isset($cache[$str])) {
-            if (!preg_match('/^{([^}]*)}(.*)$/', $str, $matches)) {
+            if (1 !== preg_match('/^{([^}]*)}(.*)$/', $str, $matches)) {
                 throw new \InvalidArgumentException('\''.$str.'\' is not a valid clark-notation formatted string');
             }
 

--- a/lib/Writer.php
+++ b/lib/Writer.php
@@ -126,7 +126,7 @@ class Writer extends \XMLWriter
                 Service::parseClarkNotation($name);
 
             if (array_key_exists($namespace, $this->namespaceMap)) {
-                $result = $this->startElementNS(
+                $result = $this->startElementNs(
                     '' === $this->namespaceMap[$namespace] ? null : $this->namespaceMap[$namespace],
                     $localName,
                     null
@@ -141,7 +141,7 @@ class Writer extends \XMLWriter
                     if (!isset($this->adhocNamespaces[$namespace])) {
                         $this->adhocNamespaces[$namespace] = 'x'.(count($this->adhocNamespaces) + 1);
                     }
-                    $result = $this->startElementNS($this->adhocNamespaces[$namespace], $localName, $namespace);
+                    $result = $this->startElementNs($this->adhocNamespaces[$namespace], $localName, $namespace);
                 }
             }
         } else {
@@ -150,7 +150,7 @@ class Writer extends \XMLWriter
 
         if (!$this->namespacesWritten) {
             foreach ($this->namespaceMap as $namespace => $prefix) {
-                $this->writeAttribute($prefix ? 'xmlns:'.$prefix : 'xmlns', $namespace);
+                $this->writeAttribute(is_string($prefix) && '' !== $prefix ? 'xmlns:'.$prefix : 'xmlns', $namespace);
             }
             $this->namespacesWritten = true;
         }
@@ -251,7 +251,7 @@ class Writer extends \XMLWriter
             $this->adhocNamespaces[$namespace] = 'x'.(count($this->adhocNamespaces) + 1);
         }
 
-        return $this->writeAttributeNS(
+        return $this->writeAttributeNs(
             $this->adhocNamespaces[$namespace],
             $localName,
             $namespace,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
 
 parameters:
   level: 8
-  phpVersion: 70430 # PHP 7.4.30
+  phpVersion: 80200 # PHP 8.2.0
   paths:
     - lib
     - tests

--- a/rector.php
+++ b/rector.php
@@ -10,7 +10,7 @@ return RectorConfig::configure()
         __DIR__.'/tests',
     ])
     // uncomment to reach your current PHP version
-    ->withPhpSets(false, false, false, false, true)
+    ->withPhpSets(false, true)
     ->withTypeCoverageLevel(0)
     ->withDeadCodeLevel(0)
     ->withCodeQualityLevel(0);

--- a/tests/Sabre/Xml/Deserializer/FunctionCallerTest.php
+++ b/tests/Sabre/Xml/Deserializer/FunctionCallerTest.php
@@ -35,7 +35,7 @@ class FunctionCallerTest extends TestCase
 XML;
 
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
         $reader->elementMap['{urn:foo}person'] = (fn (Reader $reader) => functionCaller($reader, [Person::class, 'fromXml'], 'urn:foo'));
         $reader->elementMap['{urn:foo}address'] = (fn (Reader $reader) => functionCaller($reader, [Address::class, 'fromXml'], 'urn:foo'));
         $reader->elementMap['{urn:foo}language'] = (fn (Reader $reader) => functionCaller($reader, [Language::class, 'fromXml'], 'urn:foo'));
@@ -89,7 +89,7 @@ XML;
 XML;
 
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
         $reader->elementMap['{urn:foo}person'] = (fn (Reader $reader) => functionCaller($reader, Person::class.'::fromXml', 'urn:foo'));
         $reader->elementMap['{urn:foo}address'] = (fn (Reader $reader) => functionCaller($reader, __NAMESPACE__.'\newAddressFromXml', 'urn:foo'));
         $reader->elementMap['{urn:foo}language'] = (fn (Reader $reader) => functionCaller($reader, fn (string $value): Language => new Language($value), 'urn:foo'));
@@ -116,27 +116,13 @@ XML;
         );
     }
 }
-
-final class Person
+final readonly class Person
 {
-    private string $name;
-    private int $age;
-    private Address $address;
-
-    /**
-     * @var array<int, Language|null>
-     */
-    private array $languages;
-
     /**
      * @param array<int, Language|null> $languages
      */
-    public function __construct(string $name, int $age, Address $address, array $languages)
+    public function __construct(private string $name, private int $age, private Address $address, private array $languages)
     {
-        $this->name = $name;
-        $this->age = $age;
-        $this->address = $address;
-        $this->languages = $languages;
     }
 
     /**
@@ -170,15 +156,10 @@ final class Person
         return $this->languages;
     }
 }
-final class Address
+final readonly class Address
 {
-    private string $street;
-    private int $number;
-
-    public function __construct(string $street, int $number)
+    public function __construct(private string $street, private int $number)
     {
-        $this->street = $street;
-        $this->number = $number;
     }
 
     public static function fromXml(string $street, string $number): self
@@ -196,13 +177,10 @@ final class Address
         return $this->number;
     }
 }
-final class Language
+final readonly class Language
 {
-    private string $value;
-
-    public function __construct(string $value)
+    public function __construct(private string $value)
     {
-        $this->value = $value;
     }
 
     public static function fromXml(string $value): self
@@ -215,7 +193,6 @@ final class Language
         return $this->value;
     }
 }
-
 function newAddressFromXml(string $street, string $number): Address
 {
     return new Address($street, (int) $number);

--- a/tests/Sabre/Xml/Deserializer/KeyValueTest.php
+++ b/tests/Sabre/Xml/Deserializer/KeyValueTest.php
@@ -31,7 +31,7 @@ BLA;
         $reader->elementMap = [
             '{http://sabredav.org/ns}struct' => fn (Reader $reader) => keyValue($reader, 'http://sabredav.org/ns'),
         ];
-        $reader->xml($input);
+        $reader::XML($input);
         $output = $reader->parse();
 
         self::assertEquals([
@@ -89,7 +89,7 @@ BLA;
         </foo>';
         $reader = new Reader();
 
-        $reader->xml($invalid_xml);
+        $reader::XML($invalid_xml);
         $reader->elementMap = [
             '{}Package' => function ($reader) {
                 $recipient = [];
@@ -123,7 +123,7 @@ BLA;
         $reader->elementMap = [
             '{http://sabredav.org/ns}struct' => fn (Reader $reader) => keyValue($reader, 'http://sabredav.org/ns'),
         ];
-        $reader->xml($input);
+        $reader::XML($input);
         $output = $reader->parse();
 
         self::assertEquals([

--- a/tests/Sabre/Xml/Deserializer/ValueObjectTest.php
+++ b/tests/Sabre/Xml/Deserializer/ValueObjectTest.php
@@ -20,7 +20,7 @@ class ValueObjectTest extends TestCase
 XML;
 
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
         $reader->elementMap = [
             '{urn:foo}foo' => fn (Reader $reader) => valueObject($reader, TestVo::class, 'urn:foo'),
         ];
@@ -55,7 +55,7 @@ XML;
 XML;
 
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
         $reader->elementMap = [
             '{urn:foo}foo' => fn (Reader $reader) => valueObject($reader, TestVo::class, 'urn:foo'),
         ];
@@ -90,7 +90,7 @@ XML;
 XML;
 
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
         $reader->elementMap = [
             '{urn:foo}foo' => fn (Reader $reader) => valueObject($reader, TestVo::class, 'urn:foo'),
         ];
@@ -107,7 +107,7 @@ XML;
             'attributes' => [],
         ];
 
-        $this->assertEquals(
+        $this::assertEquals(
             $expected,
             $output
         );
@@ -126,7 +126,7 @@ XML;
 XML;
 
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
         $reader->elementMap = [
             '{urn:foo}foo' => fn (Reader $reader) => valueObject($reader, TestVo::class, 'urn:foo'),
         ];
@@ -161,7 +161,7 @@ XML;
 XML;
 
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
         $reader->elementMap = [
             '{urn:foo}foo' => fn (Reader $reader) => valueObject($reader, TestVo::class, 'urn:foo'),
         ];
@@ -192,7 +192,7 @@ XML;
 XML;
 
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
         $reader->elementMap = [
             '{urn:foo}foo' => fn (Reader $reader) => valueObject($reader, TestVo::class, 'urn:foo'),
         ];
@@ -207,7 +207,7 @@ XML;
             'attributes' => [],
         ];
 
-        $this->assertEquals(
+        $this::assertEquals(
             $expected,
             $output['value'][0]
         );

--- a/tests/Sabre/Xml/Element/CDataTest.php
+++ b/tests/Sabre/Xml/Element/CDataTest.php
@@ -24,7 +24,7 @@ BLA;
         $reader->elementMap = [
             '{http://sabredav.org/ns}blabla' => Cdata::class,
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
     }

--- a/tests/Sabre/Xml/Element/Eater.php
+++ b/tests/Sabre/Xml/Element/Eater.php
@@ -53,7 +53,7 @@ class Eater implements Xml\Element
      * $reader->parseSubTree() will parse the entire sub-tree, and advance to
      * the next element.
      */
-    public static function xmlDeserialize(Xml\Reader $reader)
+    public static function xmlDeserialize(Xml\Reader $reader): void
     {
         $reader->next();
 

--- a/tests/Sabre/Xml/Element/ElementsTest.php
+++ b/tests/Sabre/Xml/Element/ElementsTest.php
@@ -36,7 +36,7 @@ BLA;
         $reader->elementMap = [
             '{http://sabredav.org/ns}listThingy' => Elements::class,
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
 

--- a/tests/Sabre/Xml/Element/KeyValueTest.php
+++ b/tests/Sabre/Xml/Element/KeyValueTest.php
@@ -35,7 +35,7 @@ BLA;
         $reader->elementMap = [
             '{http://sabredav.org/ns}struct' => KeyValue::class,
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
 
@@ -108,7 +108,7 @@ BLA;
             '{DAV:}prop' => KeyValue::class,
             '{DAV:}resourcetype' => Elements::class,
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         $expected = [
             'name' => '{DAV:}mkcol',
@@ -190,7 +190,7 @@ BLA;
         $reader->elementMap = [
             '{http://sabredav.org/ns}root' => KeyValue::class,
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
 

--- a/tests/Sabre/Xml/Element/UriTest.php
+++ b/tests/Sabre/Xml/Element/UriTest.php
@@ -24,7 +24,7 @@ BLA;
         $reader->elementMap = [
             '{http://sabredav.org/ns}uri' => Uri::class,
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
 

--- a/tests/Sabre/Xml/Element/XmlFragmentTest.php
+++ b/tests/Sabre/Xml/Element/XmlFragmentTest.php
@@ -26,7 +26,7 @@ BLA;
         $reader->elementMap = [
             '{http://sabredav.org/ns}fragment' => XmlFragment::class,
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
 

--- a/tests/Sabre/Xml/InfiniteLoopTest.php
+++ b/tests/Sabre/Xml/InfiniteLoopTest.php
@@ -24,7 +24,7 @@ class InfiniteLoopTest extends TestCase
         $reader->elementMap = [
             '{DAV:}set' => Element\KeyValue::class,
         ];
-        $reader->xml($body);
+        $reader::XML($body);
 
         $output = $reader->parse();
 

--- a/tests/Sabre/Xml/ReaderTest.php
+++ b/tests/Sabre/Xml/ReaderTest.php
@@ -15,7 +15,7 @@ class ReaderTest extends TestCase
 <root xmlns="http://sabredav.org/ns" />
 BLA;
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
 
         $reader->next();
 
@@ -29,7 +29,7 @@ BLA;
 <root />
 BLA;
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
 
         $reader->next();
 
@@ -43,7 +43,7 @@ BLA;
 <root />
 BLA;
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
 
         self::assertNull($reader->getClark());
     }
@@ -61,7 +61,7 @@ BLA;
 BLA;
 
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
 
@@ -103,7 +103,7 @@ BLA;
 BLA;
 
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
 
@@ -132,7 +132,7 @@ BLA;
 BLA;
 
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
 
@@ -166,7 +166,7 @@ BLA;
         $reader->elementMap = [
             '{http://sabredav.org/ns}elem1' => Element\Mock::class,
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
 
@@ -199,7 +199,7 @@ BLA;
         $reader->elementMap = [
             '{http://sabredav.org/ns}elem1' => new \stdClass(),
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         $reader->parse();
     }
@@ -224,7 +224,7 @@ BLA;
                 return 'foobar';
             },
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
 
@@ -263,7 +263,7 @@ BLA;
                 return 'foobar';
             },
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
 
@@ -301,7 +301,7 @@ BLA;
         $reader->elementMap = [
             '{http://sabredav.org/ns}elem1' => fn (Reader $reader) => $reader->readText(),
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
 
@@ -327,15 +327,18 @@ BLA;
 <root xmlns="http://sabredav.org/ns">
 BLA;
 
-        $reader = new Reader();
+        $reader = Reader::XML($input);
+        if (false === $reader) {
+            $this::fail('Failed to parse XML');
+        }
         $reader->elementMap = [
             '{http://sabredav.org/ns}elem1' => Element\Mock::class,
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         try {
             $output = $reader->parse();
-            $this->fail('We expected a ParseException to be thrown');
+            $this::fail('We expected a ParseException to be thrown');
         } catch (LibXMLException $e) {
             self::assertNotEmpty($e->getErrors());
         }
@@ -355,7 +358,7 @@ BLA;
         $reader->elementMap = [
             '{http://sabredav.org/ns}elem1' => Element\Eater::class,
         ];
-        $reader->xml($input);
+        $reader::XML($input);
         $reader->parse();
     }
 
@@ -373,7 +376,7 @@ BLA;
 BLA;
 
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
         $reader->parse();
     }
 
@@ -397,7 +400,7 @@ BLA;
                 </lan
 XML;
         $reader = new Reader();
-        $reader->xml($input);
+        $reader::XML($input);
         $reader->parse();
     }
 
@@ -427,7 +430,7 @@ BLA;
                 return $innerTree;
             },
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
 
@@ -478,7 +481,7 @@ BLA;
                 return $innerTree;
             },
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
 
@@ -529,7 +532,7 @@ BLA;
                 return $innerTree;
             },
         ];
-        $reader->xml($input);
+        $reader::XML($input);
 
         $output = $reader->parse();
 

--- a/tests/Sabre/Xml/ServiceTest.php
+++ b/tests/Sabre/Xml/ServiceTest.php
@@ -21,7 +21,6 @@ class ServiceTest extends TestCase
         $util->elementMap = $elems;
 
         $reader = $util->getReader();
-        self::assertInstanceOf(Reader::class, $reader);
         self::assertEquals($elems, $reader->elementMap);
     }
 
@@ -35,7 +34,6 @@ class ServiceTest extends TestCase
         $util->namespaceMap = $ns;
 
         $writer = $util->getWriter();
-        self::assertInstanceOf(Writer::class, $writer);
         self::assertEquals($ns, $writer->namespaceMap);
     }
 
@@ -382,6 +380,7 @@ XML;
     public function providesEmptyInput(): array
     {
         $emptyResource = fopen('php://input', 'r');
+        $data = [];
         $data[] = [$emptyResource];
         $data[] = [''];
 


### PR DESCRIPTION
I think I have gone too far with this.

`phpstan` tells me that the XML method of XMLReader is statis nowadays, and that calls should be like:
```
$reader = Reader::XML($input);
```

But a call like that returns an XMLReader object. We want a Sabre\Xml\Reader object that has extra methods available in it ( getClark() parse() etc.).

So I have tried overriding `XMLReader::XML` with an implementation in `Reader::XML`. That calls `parent::XML` and then makes an attempt to copy all the object vars from the returned `XMLReader` object to a new `Reader` object and reutrn that.

I have got cs-fixer, rector, and phpstan passing.

But `phpunit` complains:
`Error: Data must be loaded before reading`

So I haven't quite got the `Reader` object to be set up correctly.

I tried other ways to do this with Reflection, but no joy in copying the attributes. Maybe there is some other way to do this, or maybe this is entirely the wrong approach!

I will now make a less ambitious PR, and someone might give me clues about what approach should happen here.