### PR TITLE
chore: remove phpVersion from phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,6 @@ includes:
 
 parameters:
   level: 8
-  phpVersion: 80200 # PHP 8.2.0
   paths:
     - lib
     - tests


### PR DESCRIPTION
This is already specified in composer.json config platform php. No need to duplicate it here.