### PR TITLE
test: fix phunit10 deprecations

### DIFF
--- a/tests/Sabre/Xml/Element/XmlFragmentTest.php
+++ b/tests/Sabre/Xml/Element/XmlFragmentTest.php
@@ -56,7 +56,7 @@ BLA;
      *
      * @return array<int, array<int, string>>
      */
-    public function xmlProvider(): array
+    public static function xmlProvider(): array
     {
         return [
             [

--- a/tests/Sabre/Xml/ServiceTest.php
+++ b/tests/Sabre/Xml/ServiceTest.php
@@ -366,7 +366,7 @@ XML;
     /**
      * @return array<int, list{string, array<string>}>
      */
-    public function provideParseClarkNotationInput(): iterable
+    public static function provideParseClarkNotationInput(): iterable
     {
         return [
             ['{http://sabredav.org/ns}elem', ['http://sabredav.org/ns', 'elem']],
@@ -377,7 +377,7 @@ XML;
     /**
      * @return array<int, array<int, string|resource|false>>
      */
-    public function providesEmptyInput(): array
+    public static function providesEmptyInput(): array
     {
         $emptyResource = fopen('php://input', 'r');
         $data = [];
@@ -403,7 +403,7 @@ XML;
     /**
      * @return array<int, array<int, string>>
      */
-    public function providesEmptyPropfinds(): array
+    public static function providesEmptyPropfinds(): array
     {
         return [
             ['<D:propfind xmlns:D="DAV:"><D:prop></D:prop></D:propfind>'],

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,24 +1,13 @@
 <?xml version="1.0"?>
-<phpunit
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  colors="true"
-  bootstrap="../vendor/autoload.php"
-  convertErrorsToExceptions="true"
-  convertNoticesToExceptions="true"
-  convertWarningsToExceptions="true"
-  convertDeprecationsToExceptions="true"
-  beStrictAboutTestsThatDoNotTestAnything="true"
-  beStrictAboutOutputDuringTests="true"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-  >
-  <coverage includeUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">../lib/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="../vendor/autoload.php" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="Sabre_XML">
       <directory>.</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">../lib/</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
phpunit10 was reporting deprecations. It wants dataProvider methods to be declared static, so that is fixed here.

Also, converted phpunit.xml to version 10 format.
And set options failOnRisky and failOnWarning so that CI will fail in these cases. (That is new phpunit behavior that needs to be set, otherwise the test suite can exit with success even though there are "risky" tests or warnings)