### PR TITLE
test: migrate to phpunit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/extension-installer": "^1.4",
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^11.5",
         "rector/rector": "^2.4"
     },
     "scripts": {

--- a/tests/Sabre/Xml/Element/XmlFragmentTest.php
+++ b/tests/Sabre/Xml/Element/XmlFragmentTest.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace Sabre\Xml\Element;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sabre\Xml\Reader;
 use Sabre\Xml\Writer;
 
 class XmlFragmentTest extends TestCase
 {
-    /**
-     * @dataProvider xmlProvider
-     */
+    #[DataProvider('xmlProvider')]
     public function testDeserialize(string $input, string $expected): void
     {
         $input = <<<BLA
@@ -108,9 +107,7 @@ BLA;
         ];
     }
 
-    /**
-     * @dataProvider xmlProvider
-     */
+    #[DataProvider('xmlProvider')]
     public function testSerialize(string $expectedFallback, string $input, ?string $expected = null): void
     {
         if (is_null($expected)) {

--- a/tests/Sabre/Xml/ReaderTest.php
+++ b/tests/Sabre/Xml/ReaderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sabre\Xml;
 
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
 class ReaderTest extends TestCase
@@ -205,9 +206,7 @@ BLA;
         $reader->parse();
     }
 
-    /**
-     * @depends testMappedElement
-     */
+    #[Depends('testMappedElement')]
     public function testMappedElementCallBack(): void
     {
         $input = <<<BLA
@@ -244,9 +243,7 @@ BLA;
         self::assertEquals($expected, $output);
     }
 
-    /**
-     * @depends testMappedElementCallBack
-     */
+    #[Depends('testMappedElementCallBack')]
     public function testMappedElementCallBackNoNamespace(): void
     {
         $input = <<<BLA
@@ -283,9 +280,7 @@ BLA;
         self::assertEquals($expected, $output);
     }
 
-    /**
-     * @depends testMappedElementCallBack
-     */
+    #[Depends('testMappedElementCallBack')]
     public function testReadText(): void
     {
         $input = <<<BLA
@@ -402,9 +397,7 @@ XML;
         $reader->parse();
     }
 
-    /**
-     * @depends testMappedElement
-     */
+    #[Depends('testMappedElement')]
     public function testParseInnerTree(): void
     {
         $input = <<<BLA
@@ -453,9 +446,7 @@ BLA;
         self::assertEquals($expected, $output);
     }
 
-    /**
-     * @depends testParseInnerTree
-     */
+    #[Depends('testParseInnerTree')]
     public function testParseGetElements(): void
     {
         $input = <<<BLA
@@ -504,9 +495,7 @@ BLA;
         self::assertEquals($expected, $output);
     }
 
-    /**
-     * @depends testParseInnerTree
-     */
+    #[Depends('testParseInnerTree')]
     public function testParseGetElementsNoElements(): void
     {
         $input = <<<BLA

--- a/tests/Sabre/Xml/ServiceTest.php
+++ b/tests/Sabre/Xml/ServiceTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sabre\Xml;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Sabre\Xml\Element\KeyValue;
 
@@ -38,10 +40,9 @@ class ServiceTest extends TestCase
     }
 
     /**
-     * @dataProvider providesEmptyInput
-     *
      * @param string|resource $input
      */
+    #[DataProvider('providesEmptyInput')]
     public function testEmptyInputParse($input): void
     {
         $this->expectException(ParseException::class);
@@ -51,9 +52,7 @@ class ServiceTest extends TestCase
         $util->parse($input, '/sabre.io/ns');
     }
 
-    /**
-     * @depends testGetReader
-     */
+    #[Depends('testGetReader')]
     public function testParse(): void
     {
         $xml = <<<XML
@@ -79,9 +78,7 @@ XML;
         );
     }
 
-    /**
-     * @depends testGetReader
-     */
+    #[Depends('testGetReader')]
     public function testParseStream(): void
     {
         $xml = <<<XML
@@ -113,10 +110,9 @@ XML;
     }
 
     /**
-     * @dataProvider providesEmptyInput
-     *
      * @param string|resource $input
      */
+    #[DataProvider('providesEmptyInput')]
     public function testEmptyInputExpect($input): void
     {
         $this->expectException(ParseException::class);
@@ -126,9 +122,7 @@ XML;
         $util->expect('foo', $input, '/sabre.io/ns');
     }
 
-    /**
-     * @depends testGetReader
-     */
+    #[Depends('testGetReader')]
     public function testExpect(): void
     {
         $xml = <<<XML
@@ -168,9 +162,7 @@ XML;
         $result = $util->expect('{DAV:}propfind', $xml);
     }
 
-    /**
-     * @dataProvider providesEmptyPropfinds
-     */
+    #[DataProvider('providesEmptyPropfinds')]
     public function testEmptyPropfind(string $xml): void
     {
         $util = new Service();
@@ -187,9 +179,7 @@ XML;
         self::assertEquals([], $result->properties);
     }
 
-    /**
-     * @depends testGetReader
-     */
+    #[Depends('testGetReader')]
     public function testExpectStream(): void
     {
         $xml = <<<XML
@@ -220,9 +210,7 @@ XML;
         );
     }
 
-    /**
-     * @depends testGetReader
-     */
+    #[Depends('testGetReader')]
     public function testExpectWrong(): void
     {
         $this->expectException(ParseException::class);
@@ -235,9 +223,7 @@ XML;
         $util->expect('{http://sabre.io/ns}error', $xml);
     }
 
-    /**
-     * @depends testGetWriter
-     */
+    #[Depends('testGetWriter')]
     public function testWrite(): void
     {
         $util = new Service();
@@ -349,9 +335,8 @@ XML;
 
     /**
      * @param array<string> $expected
-     *
-     * @dataProvider provideParseClarkNotationInput
      */
+    #[DataProvider('provideParseClarkNotationInput')]
     public function testParseClarkNotation(string $clark, array $expected): void
     {
         self::assertEquals($expected, Service::parseClarkNotation($clark));

--- a/tests/Sabre/Xml/WriterTest.php
+++ b/tests/Sabre/Xml/WriterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sabre\Xml;
 
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
 class WriterTest extends TestCase
@@ -42,9 +43,7 @@ HI
         );
     }
 
-    /**
-     * @depends testSimple
-     */
+    #[Depends('testSimple')]
     public function testSimpleQuotes(): void
     {
         $this->compare([
@@ -177,9 +176,7 @@ HI
         );
     }
 
-    /**
-     * @depends testArrayFormat2
-     */
+    #[Depends('testArrayFormat2')]
     public function testArrayFormat2NoValue(): void
     {
         $this->compare([


### PR DESCRIPTION
convert test annotations to PHP attributes

The XML schema is the same for PHPunit 10 and 11,
so that does not need to be migrated.